### PR TITLE
Refactor of memory management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.a
 a.out
 *.o
 test.bin
@@ -8,3 +9,7 @@ convergence.dat
 *.sp5
 *.lst
 *.s
+KokkosCore_*
+core.*
+simple_test_cuda
+*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,4 @@ before_install:
 script:
   - cd test
   - make test USE_HDF5=yes
+  - valgrind --leak-check=yes --track-origins=yes ./test.bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     packages:
       - build-essential
       - libhdf5-dev
+      - valgrind
 
 before_install:
   - wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh

--- a/databox.hpp
+++ b/databox.hpp
@@ -50,12 +50,7 @@ namespace Spiner {
   public:
 
     // Base constructor
-    PORTABLE_INLINE_FUNCTION __attribute__((nothrow))
-    DataBox()
-      : rank_(0)
-    {
-      finalize();
-    }
+    DataBox() = default;
 
     // Rank constructors w/ pointer
     // args should be ints.
@@ -303,7 +298,7 @@ namespace Spiner {
 #ifdef PORTABILITY_STRATEGY_KOKKOS
       using HS = Kokkos::HostSpace;
       using DMS = Kokkos::DefaultExecutionSpace::memory_space;
-      constexpr const bool execution_is_host {std::is_same<DMS,HS>::value};
+      constexpr const bool execution_is_host {Kokkos::SpaceAccessibility<DMS,HS>::accessible};
       if (execution_is_host) {
         DataBox a;
         a.copy(*this);
@@ -345,7 +340,7 @@ namespace Spiner {
     }
 
   private:
-    int rank_; // after dataView_ b/c dataView_ should be initialized first
+    int rank_ = 0; // after dataView_ b/c dataView_ should be initialized first
     DataStatus status_ = DataStatus::Empty;
     // when we manage our own data on host, it lives here
     Real* data_ = nullptr; // points at data, managed or not

--- a/databox.hpp
+++ b/databox.hpp
@@ -395,7 +395,7 @@ namespace Spiner {
     inline void copy(const DataBox& src);
 
     // utility info
-    inline DataStatus dataStatus() { return status_; }
+    inline DataStatus dataStatus() const { return status_; }
     inline bool isReference() { return status_ == DataStatus::shallow_slice; }
     inline bool ownsAllocatedMemory() {
       return (status_ == DataStatus::empty

--- a/databox.hpp
+++ b/databox.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 #include <string>
 #include <limits>
+
 #include <assert.h>
 
 #ifdef SPINER_USE_HDF
@@ -47,72 +48,22 @@ namespace Spiner {
   public:
 
     // Base constructor
-    PORTABLE_INLINE_FUNCTION __attribute__((nothrow)) DataBox()
+    PORTABLE_INLINE_FUNCTION __attribute__((nothrow))
+    DataBox()
       : rank_(0)
       , status_(DataStatus::empty)
       , data_(nullptr)
     {}
 
     // Rank constructors w/ pointer
+    template<typename... Args>
     PORTABLE_INLINE_FUNCTION __attribute__((nothrow))
-    DataBox(Real* data, int nx1)
-      : rank_(1)
+    DataBox(Real* data, Args... args)
+      : rank_(sizeof...(args))
       , status_(DataStatus::shallow_slice)
       , data_(data)
     {
-      dataView_.NewPortableMDArray(data, nx1);
-      setAllIndexed_();
-    }
-    PORTABLE_INLINE_FUNCTION __attribute__((nothrow))
-    DataBox(Real* data, int nx2, int nx1)
-      : rank_(2)
-      , status_(DataStatus::shallow_slice)
-      , data_(data)
-    {
-      dataView_.NewPortableMDArray(data, nx2,nx1);
-      setAllIndexed_();
-    }
-    PORTABLE_INLINE_FUNCTION __attribute__((nothrow))
-    DataBox(Real* data,
-            int nx3, int nx2, int nx1)
-      : rank_(3)
-      , status_(DataStatus::shallow_slice)
-      , data_(data)
-    {
-      dataView_.NewPortableMDArray(data, nx3,nx2,nx1);
-      setAllIndexed_();
-    }
-    PORTABLE_INLINE_FUNCTION __attribute__((nothrow))
-    DataBox(Real* data,
-            int nx4, int nx3,
-            int nx2, int nx1)
-      : rank_(4)
-      , status_(DataStatus::shallow_slice)
-      , data_(data)
-    {
-      dataView_.NewPortableMDArray(data, nx4,nx3,nx2,nx1);
-      setAllIndexed_();
-    }
-    PORTABLE_INLINE_FUNCTION __attribute__((nothrow))
-    DataBox(Real* data,
-            int nx5, int nx4,
-            int nx3, int nx2, int nx1)
-      : rank_(5)
-      , status_(DataStatus::shallow_slice)
-      , data_(data)
-    {
-      dataView_.NewPortableMDArray(data, nx5,nx4,nx3,nx2,nx1);
-      setAllIndexed_();
-    }
-    PORTABLE_INLINE_FUNCTION __attribute__((nothrow))
-    DataBox(Real* data,
-            int nx6, int nx5, int nx4,
-            int nx3, int nx2, int nx1)
-      : rank_(6)
-      , status_(DataStatus::shallow_slice)
-      , data_(data)
-    {
-      dataView_.NewPortableMDArray(data, nx6,nx5,nx4,nx3,nx2,nx1);
+      dataView_.NewPortableMDArray(data, std::forward<Args>(args)...);
       setAllIndexed_();
     }
 

--- a/ports-of-call/portable_arrays.hpp
+++ b/ports-of-call/portable_arrays.hpp
@@ -18,9 +18,7 @@
 // distribute copies to the public, perform publicly and display
 // publicly, and to permit others to do so.
 // ========================================================================================
-// ! \file athena_arrays.hpp \brief provides array classes valid in 1D
-// to 5D.
-//
+
 //  The operator() is overloaded, e.g. elements of a 4D array of size [N4xN3xN2xN1]
 //  are accessed as:  A(n,k,j,i) = A[i + N1*(j + N2*(k + N3*n))]
 //  NOTE THE TRAILING INDEX INSIDE THE PARENTHESES IS INDEXED FASTEST

--- a/test/Makefile.kokkos
+++ b/test/Makefile.kokkos
@@ -12,8 +12,8 @@
 # permit others to do so.
 
 KOKKOS_PATH = ${HOME}/kokkos
-#SRC = test.cpp
-SRC = convergence.cpp
+SRC = test.cpp
+#SRC = convergence.cpp
 vpath %.cpp $(sort $(dir $(SRC)))
 
 KOKKOS_CXX_STANDARD=c++14
@@ -28,7 +28,7 @@ default: build
 
 ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
 CXX = ${KOKKOS_PATH}/bin/nvcc_wrapper
-CXXFLAGS = -O3 --expt-relaxed-constexpr
+CXXFLAGS = -O0 --expt-relaxed-constexpr -g
 CXXFLAGS += -DPORTABILITY_STRATEGY_KOKKOS #-DSPINER_USE_HDF
 LINK = ${CXX}
 #LDFLAGS = 
@@ -42,17 +42,17 @@ LDFLAGS =
 EXE = simple_test_cuda
 else
 CXX = g++
-CXXFLAGS = -O3 -g -DPORTABILITY_STRATEGY_KOKKOS #-DSPINER_USE_HDF
+CXXFLAGS = -O0 -g -DPORTABILITY_STRATEGY_KOKKOS #-DSPINER_USE_HDF
 LINK = ${CXX}
 LDFLAGS = #-lhdf5_hl -lhdf5 -Wl,-rpath=${H5_DIR}/lib/
-#EXE = simple_test
-EXE = convergence_test
+EXE = simple_test
+#EXE = convergence_test
 KOKKOS_DEVICES = "OpenMP"
 KOKKOS_ARCH = ""
 #KOKKOS_DEBUG=yes
 endif
 
-EXTRA_INC += -ICatch2/single_include/catch2 -Iports-of-call
+EXTRA_INC += -I../Catch2/single_include/catch2 -I../ports-of-call -I../
 #EXTRA_INC += ${H5_INCLUDE}
 DEPFLAGS = -M
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -300,6 +300,37 @@ TEST_CASE( "DataBox interpolation", "[DataBox]" ) {
   }
 }
 
+DataBox MakeFilledDB(int N, int &tot) {
+  DataBox db(N, N, N);
+  tot = 0;
+  for (int k = 0; k < N; k++) {
+    for (int j = 0; j < N; j++) {
+      for (int i = 0; i < N; i++) {
+        db(k,j,i) = tot++;
+      }
+    }
+  }
+  db.setRange(0,0,1,10);
+  return db;
+}
+SCENARIO( "Reference Counting", "[DataBox]" ) {
+  WHEN("A databox is asigned and the original one goes out of scope") {
+    constexpr int N = 2;
+    int tot;
+    DataBox db;
+    {
+      auto db2 = MakeFilledDB(N,tot);
+      db = db2;
+    }
+    THEN("The databox status is correct") {
+      REQUIRE( db.dataStatus() == Spiner::DataStatus::AllocatedHost );
+      AND_THEN( "The data is present" ) {
+        REQUIRE( db(N-1, N-1, N-1) == tot - 1 );
+      }
+    }
+  }
+}
+
 #if SPINER_USE_HDF
 SCENARIO( "DataBox HDF5", "[DataBox],[HDF5]" ) {
   constexpr int N = 2;


### PR DESCRIPTION
A bug in downstream code `singularity-eos` prompted me to run `valgrind` on `Spiner`. I discovered a number of issues with `Spiner`'s pseudo-reference-counting where it tried to manage its own memory on the host but gave up on the device. This design had several problems:
1. It was conceptually difficult to track and bug-prone. 
2. A `DataBox` that managed memory could not go out of scope. If it did, all `DataBox`es that depended on it would be pointing at unitialized memory.

I therefore re-design `DataBox` memory management in this PR. I do the following:
1. `DataBox`es can *allocate* memory. They free memory before re-allocating, but otherwise never free memory.
2. Freeing memory must be performed externally via the `DataBox::finalize()` or `free(DataBox&)` methods, which release allocated memory.

This provides several advantages. 
- First, it avoids the aforementioned problems. 
- Second, with a little tracking, we can now control where a `DataBox` allocates memory more finely. I now provide constructors and "resetter"s that can tell `DataBox` *where* to allocate. You can allocate on the device via, e.g.,
```C++
Spiner::DataBox db(Spiner::AllocationTarget::Device, n3, n2, n1);
```
and you can always free via
```C++
free(db);
```
no matter where the data is located.
- Finally, the `free()` mechanism allows to subsume our databox to smart pointers and reference count them that way if desired. To enable this, we provide the `Spiner::DBDeleter` class defined as
```C++
  struct DBDeleter {
    template<typename T>
    void operator()(T* ptr) {
      ptr->finalize();
      delete ptr;
    }
  };
``` 
This can be used as, for example,
```C++
std::unique_ptr<DataBox, Spiner::DBDeleter> pdb(new DataBox(Spiner::AllocationTarget::Device, N));
auto db = *pdb;
portableFor("Just do something", 0, N, PORTABLE_LAMBDA(int i) { db(i) = 2.0*i; });
```
which will automatically garbage collect the device memory when `pdb` goes out of scope.

Thanks to @jdolence and @dholladay00 for useful discussions while I chased this down. Thanks @brryan for the idea about the custom deleter for the shared pointer. @jdolence @dholladay00 please take a look at this and let me know what you think. I'd like to merge it in quickly. Then I will need to update `singularity-eos` to utilize the new API.