### PR TITLE
More interpolation operations

### DIFF
--- a/databox.hpp
+++ b/databox.hpp
@@ -319,7 +319,7 @@ namespace Spiner {
       if (execution_is_host) {
         DataBox a;
         a.copy(*this);
-        a.status_ = DataStatus::AllocatedDevice;
+        a.status_ = DataStatus::AllocatedHost;
         return a;
       } else {
         using memUnmanaged = Kokkos::MemoryUnmanaged;
@@ -340,7 +340,7 @@ namespace Spiner {
 #else // no kokkos
       DataBox a;
       a.copy(*this);
-      a.status_ = DataStatus::AllocatedDevice;
+      a.status_ = DataStatus::AllocatedHost;
       return a;
 #endif // kokkos
     }

--- a/databox.hpp
+++ b/databox.hpp
@@ -201,6 +201,23 @@ namespace Spiner {
     interpToReal(const Real x3,
                  const Real x2,
                  const Real x1) const;
+    PORTABLE_INLINE_FUNCTION Real
+    __attribute__((nothrow)) __attribute__((always_inline))
+    interpToReal(const Real x4,
+		 const Real x3,
+                 const Real x2,
+                 const Real x1) const;
+    // Interpolates the whole databox to a real number,
+    // with one intermediate, non-interpolatable index,
+    // which is simply indexed into
+    // JMM: Trust me---this is a common pattern
+    PORTABLE_INLINE_FUNCTION Real
+    __attribute__((nothrow)) __attribute__((always_inline))
+    interpToReal(const Real x4,
+		 const Real x3,
+                 const Real x2,
+		 const int idx,
+                 const Real x1) const;
     // Interpolates SLOWEST indices of databox to a new
     // DataBox, interpolated at that slowest index.
     // WARNING: requires memory to be pre-allocated.
@@ -415,12 +432,6 @@ namespace Spiner {
                    +w1[1]*dataView_(ix2,ix1+1))
             + w2[1]*(w1[0]*dataView_(ix2+1,ix1)
                      +w1[1]*dataView_(ix2+1,ix1+1)));
-    /*
-    return (   w2[0]*w1[0]*dataView_(ix2,   ix1  )
-             + w2[0]*w1[1]*dataView_(ix2,   ix1+1)
-             + w2[1]*w1[0]*dataView_(ix2+1, ix1  )
-             + w2[1]*w1[1]*dataView_(ix2+1, ix1+1));
-    */
   }
 
   PORTABLE_INLINE_FUNCTION Real
@@ -436,24 +447,108 @@ namespace Spiner {
     grids_[2].weights(x3,ix[2],w[2]);
     // TODO: prefect corners for speed?
     // TODO: re-order access pattern?
-    return (w[2][0]*(w[1][0]*(w[0][0]*dataView_(ix[2],ix[1],ix[0])
-                              +w[0][1]*dataView_(ix[2],ix[1],ix[0]+1))
-                     +(w[1][1]*(w[0][0]*dataView_(ix[2],ix[1]+1,ix[0])
-                                +w[0][1]*dataView_(ix[2],ix[1]+1,ix[0]+1))))
-            + w[2][1]*(w[1][0]*(w[0][0]*dataView_(ix[2]+1,ix[1],ix[0])
-                                +w[0][1]*dataView_(ix[2]+1,ix[1],ix[0]+1))
-                       + w[1][1]*(w[0][0]*dataView_(ix[2]+1,ix[1]+1,ix[0])
-                                  +w[0][1]*dataView_(ix[2]+1,ix[1]+1,ix[0]+1))));
-    /*
-    return (   w[2][0]*w[1][0]*w[0][0]*dataView_(ix[2],   ix[1],   ix[0]  )
-             + w[2][0]*w[1][0]*w[0][1]*dataView_(ix[2],   ix[1],   ix[0]+1)
-             + w[2][0]*w[1][1]*w[0][0]*dataView_(ix[2],   ix[1]+1, ix[0]  )
-             + w[2][0]*w[1][1]*w[0][1]*dataView_(ix[2],   ix[1]+1, ix[0]+1)
-             + w[2][1]*w[1][0]*w[0][0]*dataView_(ix[2]+1, ix[1],   ix[0]  )
-             + w[2][1]*w[1][0]*w[0][1]*dataView_(ix[2]+1, ix[1],   ix[0]+1)
-             + w[2][1]*w[1][1]*w[0][0]*dataView_(ix[2]+1, ix[1]+1, ix[0]  )
-             + w[2][1]*w[1][1]*w[0][1]*dataView_(ix[2]+1, ix[1]+1, ix[0]+1));
-    */
+    return (w[2][0] * (w[1][0] * (w[0][0] * dataView_(ix[2], ix[1], ix[0]) +
+                                  w[0][1] * dataView_(ix[2], ix[1], ix[0] + 1)) +
+                       w[1][1] * (w[0][0] * dataView_(ix[2], ix[1] + 1, ix[0]) +
+                                  w[0][1] * dataView_(ix[2], ix[1] + 1, ix[0] + 1))) +
+            w[2][1] * (w[1][0] * (w[0][0] * dataView_(ix[2] + 1, ix[1], ix[0]) +
+                                  w[0][1] * dataView_(ix[2] + 1, ix[1], ix[0] + 1)) +
+                       w[1][1] * (w[0][0] * dataView_(ix[2] + 1, ix[1] + 1, ix[0]) +
+                                  w[0][1] * dataView_(ix[2] + 1, ix[1] + 1, ix[0] + 1))));
+  }
+
+  PORTABLE_INLINE_FUNCTION Real
+  __attribute__((nothrow)) __attribute__((always_inline))
+  DataBox::interpToReal(const Real x4,
+			const Real x3,
+			const Real x2,
+			const Real x1) const {
+    assert( canInterpToReal_(4) );
+    Real x[] = {x1, x2, x3, x4};
+    int ix[4];
+    weights_t w[4];
+    for (int i = 0; i < 4; ++i) {
+      grids_[i].weights(x[i], ix[i], w[i]);
+    }
+    // TODO(JMM): This is getty pretty gross. Should we automate?
+    // Hand-written is probably faster, though.
+    // Breaking line-limit to make this easier to read
+    return (
+        w[3][0] *
+            (w[2][0] *
+                 (w[1][0] * (w[0][0] * dataView_(ix[3], ix[2], ix[1], ix[0]) +
+                             w[0][1] * dataView_(ix[3], ix[2], ix[1], ix[0] + 1)) +
+                  w[1][1] * (w[0][0] * dataView_(ix[3], ix[2], ix[1] + 1, ix[0]) +
+                             w[0][1] * dataView_(ix[3], ix[2], ix[1] + 1, ix[0] + 1))) +
+             w[2][1] *
+                 (w[1][0] * (w[0][0] * dataView_(ix[3], ix[2] + 1, ix[1], ix[0]) +
+                             w[0][1] * dataView_(ix[3], ix[2] + 1, ix[1], ix[0] + 1)) +
+                  w[1][1] * (w[0][0] * dataView_(ix[3], ix[2] + 1, ix[1] + 1, ix[0]) +
+			     w[0][1] * dataView_(ix[3], ix[2] + 1, ix[1] + 1, ix[0] + 1)))) +
+        w[3][1] *
+            (w[2][0] *
+                 (w[1][0] * (w[0][0] * dataView_(ix[3] + 1, ix[2], ix[1], ix[0]) +
+                             w[0][1] * dataView_(ix[3] + 1, ix[2], ix[1], ix[0] + 1)) +
+                  w[1][1] * (w[0][0] * dataView_(ix[3] + 1, ix[2], ix[1] + 1, ix[0]) +
+			     w[0][1] * dataView_(ix[3] + 1, ix[2], ix[1] + 1, ix[0] + 1))) +
+             w[2][1] *
+                 (w[1][0] * (w[0][0] * dataView_(ix[3] + 1, ix[2] + 1, ix[1], ix[0]) +
+			     w[0][1] * dataView_(ix[3] + 1, ix[2] + 1, ix[1], ix[0] + 1)) +
+                  w[1][1] * (w[0][0] * dataView_(ix[3] + 1, ix[2] + 1, ix[1] + 1, ix[0]) +
+			     w[0][1] * dataView_(ix[3] + 1, ix[2] + 1, ix[1] + 1, ix[0] + 1))))
+
+    );
+  }
+
+  PORTABLE_INLINE_FUNCTION Real
+  __attribute__((nothrow)) __attribute__((always_inline))
+  DataBox::interpToReal(const Real x4,
+			const Real x3,
+			const Real x2,
+			const int idx,
+			const Real x1) const {
+    assert( rank_ == interpOrder + 1 );
+    assert( indices_[0] == IndexType::Interpolated );
+    assert( grids_[0].isWellFormed() );
+    for (int i = 2; i < 5; ++i) {
+      assert( indices_[i] == IndexType::Interpolated );
+      assert( grids_[i].isWellFormed() );
+    }
+    Real x[] = {x1, x2, x3, x4};
+    int ix[4];
+    weights_t w[4];
+    grids_[0].weights(x[0], ix[0], w[0]);
+    for (int i = 1; i < 4; ++i) {
+      grids_[i+1].weights(x[i], ix[i], w[i]);
+    }
+    // TODO(JMM): This is getty pretty gross. Should we automate?
+    // Hand-written is probably faster, though.
+    // Breaking line-limit to make this easier to read
+    return (
+        w[3][0] *
+            (w[2][0] *
+                 (w[1][0] * (w[0][0] * dataView_(ix[3], ix[2], ix[1], idx, ix[0]) +
+                             w[0][1] * dataView_(ix[3], ix[2], ix[1], idx, ix[0] + 1)) +
+                  w[1][1] * (w[0][0] * dataView_(ix[3], ix[2], ix[1] + 1, idx, ix[0]) +
+                             w[0][1] * dataView_(ix[3], ix[2], ix[1] + 1, idx, ix[0] + 1))) +
+             w[2][1] *
+                 (w[1][0] * (w[0][0] * dataView_(ix[3], ix[2] + 1, ix[1], idx, ix[0]) +
+                             w[0][1] * dataView_(ix[3], ix[2] + 1, ix[1], idx, ix[0] + 1)) +
+                  w[1][1] * (w[0][0] * dataView_(ix[3], ix[2] + 1, ix[1] + 1, idx, ix[0]) +
+			     w[0][1] * dataView_(ix[3], ix[2] + 1, ix[1] + 1, idx, ix[0] + 1)))) +
+        w[3][1] *
+            (w[2][0] *
+                 (w[1][0] * (w[0][0] * dataView_(ix[3] + 1, ix[2], ix[1], idx, ix[0]) +
+                             w[0][1] * dataView_(ix[3] + 1, ix[2], ix[1], idx, ix[0] + 1)) +
+                  w[1][1] * (w[0][0] * dataView_(ix[3] + 1, ix[2], ix[1] + 1, idx, ix[0]) +
+			     w[0][1] * dataView_(ix[3] + 1, ix[2], ix[1] + 1, idx, ix[0] + 1))) +
+             w[2][1] *
+                 (w[1][0] * (w[0][0] * dataView_(ix[3] + 1, ix[2] + 1, ix[1], idx, ix[0]) +
+			     w[0][1] * dataView_(ix[3] + 1, ix[2] + 1, ix[1], idx, ix[0] + 1)) +
+                  w[1][1] * (w[0][0] * dataView_(ix[3] + 1, ix[2] + 1, ix[1] + 1, idx, ix[0]) +
+			     w[0][1] * dataView_(ix[3] + 1, ix[2] + 1, ix[1] + 1, idx, ix[0] + 1))))
+
+    );
   }
 
   PORTABLE_INLINE_FUNCTION void DataBox::interpFromDB(const DataBox& db,

--- a/databox.hpp
+++ b/databox.hpp
@@ -317,9 +317,11 @@ namespace Spiner {
       using DMS = Kokkos::DefaultExecutionSpace::memory_space;
       constexpr const bool execution_is_host {Kokkos::SpaceAccessibility<DMS,HS>::accessible};
       if (execution_is_host) {
+	printf("Execution is host\n");
         DataBox a;
         a.copy(*this);
-        a.status_ = DataStatus::AllocatedHost;
+	// Handled by copy
+        // a.status_ = DataStatus::AllocatedDevice;
         return a;
       } else {
         using memUnmanaged = Kokkos::MemoryUnmanaged;
@@ -340,7 +342,8 @@ namespace Spiner {
 #else // no kokkos
       DataBox a;
       a.copy(*this);
-      a.status_ = DataStatus::AllocatedHost;
+      // Handled by copy
+      // a.status_ = DataStatus::AllocatedDevice;
       return a;
 #endif // kokkos
     }

--- a/databox.hpp
+++ b/databox.hpp
@@ -317,11 +317,8 @@ namespace Spiner {
       using DMS = Kokkos::DefaultExecutionSpace::memory_space;
       constexpr const bool execution_is_host {Kokkos::SpaceAccessibility<DMS,HS>::accessible};
       if (execution_is_host) {
-	printf("Execution is host\n");
         DataBox a;
-        a.copy(*this);
-	// Handled by copy
-        // a.status_ = DataStatus::AllocatedDevice;
+        a.copy(*this); // a.copy handles setting allocation status
         return a;
       } else {
         using memUnmanaged = Kokkos::MemoryUnmanaged;
@@ -341,9 +338,7 @@ namespace Spiner {
       }
 #else // no kokkos
       DataBox a;
-      a.copy(*this);
-      // Handled by copy
-      // a.status_ = DataStatus::AllocatedDevice;
+      a.copy(*this); // a.copy handles allocation status.
       return a;
 #endif // kokkos
     }

--- a/databox.hpp
+++ b/databox.hpp
@@ -507,7 +507,7 @@ namespace Spiner {
 			const Real x2,
 			const int idx,
 			const Real x1) const {
-    assert( rank_ == interpOrder + 1 );
+    assert( rank_ == 5 );
     assert( indices_[0] == IndexType::Interpolated );
     assert( grids_[0].isWellFormed() );
     for (int i = 2; i < 5; ++i) {

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -162,7 +162,7 @@ void portableFor(const char* name,
   using Policy5D = Kokkos::MDRangePolicy<Kokkos::Rank<5>>;
   Kokkos::parallel_for(name,
 		       Policy5D({startb,starta,startz,starty,startx},
-				{stopa,stopz,stopy,stopx}),
+				{stopb,stopa,stopz,stopy,stopx}),
 		       function);
 #else
   for (int ib = startb; ib < stopb; ib++) {
@@ -244,7 +244,7 @@ void portableReduce(const char* name,
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using Policy5D = Kokkos::MDRangePolicy<Kokkos::Rank<5>>;
   Kokkos::parallel_reduce(name,
-			  Policy4D({startb, starta,startz,starty,startx},
+			  Policy5D({startb, starta,startz,starty,startx},
 				   {stopb, stopa,stopz,stopy,stopx}),
 			  function,
 			  reduced);

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -165,7 +165,7 @@ void portableFor(const char* name,
 				{stopa,stopz,stopy,stopx}),
 		       function);
 #else
-  for (int ib = starb; ib < stopb; ib++) {
+  for (int ib = startb; ib < stopb; ib++) {
     for (int ia = starta; ia < stopa; ia++) {
       for (int iz = startz; iz < stopz; iz++) {
 	for (int iy = starty; iy < stopy; iy++) {
@@ -254,7 +254,7 @@ void portableReduce(const char* name,
       for (int iz = startz; iz < stopz; iz++) {
 	for (int iy = starty; iy < stopy; iy++) {
 	  for (int ix = startx; ix < stopx; ix++) {
-	    function(ia,iz,iy,ix, reduced);
+	    function(ib, ia,iz,iy,ix, reduced);
 	  }
 	}
       }

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -134,7 +134,7 @@ void portableFor(const char* name,
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using Policy4D = Kokkos::MDRangePolicy<Kokkos::Rank<4>>;
   Kokkos::parallel_for(name,
-		       Policy3D({starta,startz,starty,startx},
+		       Policy4D({starta,startz,starty,startx},
 				{stopa,stopz,stopy,stopx}),
 		       function);
 #else
@@ -143,6 +143,35 @@ void portableFor(const char* name,
       for (int iy = starty; iy < stopy; iy++) {
 	for (int ix = startx; ix < stopx; ix++) {
 	  function(ia,iz,iy,ix);
+	}
+      }
+    }
+  }
+#endif
+}
+
+template <typename Function>
+void portableFor(const char* name,
+		 int startb, int stopb,
+		 int starta, int stopa,
+		 int startz, int stopz,
+		 int starty, int stopy,
+		 int startx, int stopx,
+		 Function function) {
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  using Policy5D = Kokkos::MDRangePolicy<Kokkos::Rank<5>>;
+  Kokkos::parallel_for(name,
+		       Policy5D({startb,starta,startz,starty,startx},
+				{stopa,stopz,stopy,stopx}),
+		       function);
+#else
+  for (int ib = starb; ib < stopb; ib++) {
+    for (int ia = starta; ia < stopa; ia++) {
+      for (int iz = startz; iz < stopz; iz++) {
+	for (int iy = starty; iy < stopy; iy++) {
+	  for (int ix = startx; ix < stopx; ix++) {
+	    function(ib, ia,iz,iy,ix);
+	  }
 	}
       }
     }
@@ -203,5 +232,35 @@ void portableReduce(const char* name,
 #endif
 }
 
+template <typename Function, typename T>
+void portableReduce(const char* name,
+		    int startb, int stopb,
+		    int starta, int stopa,
+		    int startz, int stopz,
+		    int starty, int stopy,
+		    int startx, int stopx,
+		    Function function,
+		    T& reduced) {
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+  using Policy5D = Kokkos::MDRangePolicy<Kokkos::Rank<5>>;
+  Kokkos::parallel_reduce(name,
+			  Policy4D({startb, starta,startz,starty,startx},
+				   {stopb, stopa,stopz,stopy,stopx}),
+			  function,
+			  reduced);
+#else
+  for (int ib = startb; ib < stopb; ib++) {
+    for (int ia = starta; ia < stopa; ia++) {
+      for (int iz = startz; iz < stopz; iz++) {
+	for (int iy = starty; iy < stopy; iy++) {
+	  for (int ix = startx; ix < stopx; ix++) {
+	    function(ia,iz,iy,ix, reduced);
+	  }
+	}
+      }
+    }
+  }
+#endif
+}
 
 #endif // PORTABILITY_HPP

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -186,7 +186,7 @@ void portableReduce(const char* name,
 #ifdef PORTABILITY_STRATEGY_KOKKOS
   using Policy4D = Kokkos::MDRangePolicy<Kokkos::Rank<4>>;
   Kokkos::parallel_reduce(name,
-			  Policy3D({starta,startz,starty,startx},
+			  Policy4D({starta,startz,starty,startx},
 				   {stopa,stopz,stopy,stopx}),
 			  function,
 			  reduced);
@@ -195,7 +195,7 @@ void portableReduce(const char* name,
     for (int iz = startz; iz < stopz; iz++) {
       for (int iy = starty; iy < stopy; iy++) {
 	for (int ix = startx; ix < stopx; ix++) {
-	  function(iz,iy,ix, reduced);
+	  function(ia,iz,iy,ix, reduced);
 	}
       }
     }

--- a/test/Makefile.kokkos
+++ b/test/Makefile.kokkos
@@ -70,7 +70,7 @@ $(EXE): $(OBJ) $(KOKKOS_LINK_DEPENDS)
 	$(LINK) $(KOKKOS_LDFLAGS) $(LDFLAGS) $(EXTRA_PATH) $(OBJ) $(KOKKOS_LIBS) $(LIB) -o $(EXE)
 
 clean: kokkos-clean 
-	rm -f *.o *.cuda *.host *.rocm
+	rm -f *.o *.cuda *.host *.rocm ${EXE}
 
 # Compilation rules
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -176,7 +176,7 @@ TEST_CASE( "DataBox interpolation", "[DataBox]" ) {
     constexpr int NCOARSE = 5;
     constexpr int NFINE = 20;
     constexpr int RANK  = 4;
-    DataBox db(Spiner::AllocationTarget::Device, NCOARSe, NCOARSE, NCOARSe, NCOARSE);
+    DataBox db(Spiner::AllocationTarget::Device, NCOARSE, NCOARSE, NCOARSE, NCOARSE);
     
     constexpr Real xmin = 0;
     constexpr Real xmax = 1;
@@ -192,7 +192,7 @@ TEST_CASE( "DataBox interpolation", "[DataBox]" ) {
 		  Real x = grid.x(ix);
 		  db(ia, iz, iy, ix) = linearFunction(a,z,y,x);
 		});
-    THEN("interpToReal in 2D is exact for linear functions") {
+    THEN("interpToReal in 4D with one non-interpolated index is exact for linear functions") {
       Real error = 0;
       portableReduce("Interpolate 4D databox", 0, NFINE, 0, NFINE, 0, NFINE, 0, NFINE,
                      PORTABLE_LAMBDA(const int ia, const int iz, const int iy,
@@ -204,7 +204,7 @@ TEST_CASE( "DataBox interpolation", "[DataBox]" ) {
 		       Real x = grid.x(ix);
 		       Real f_true = linearFunction(a,z,y,x);
 		       Real difference = db.interpToReal(a,z,y,x) - f_true;
-		       error += (difference*difference);
+		       accumulate += (difference*difference);
                      }, error);
       REQUIRE( error <= EPSTEST );
     }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -218,7 +218,6 @@ TEST_CASE( "DataBox interpolation", "[DataBox]" ) {
     constexpr int NCOARSE = 5;
     constexpr int NIDX = 5;
     constexpr int NFINE = 20;
-    constexpr int RANK  = 5;
     DataBox db(Spiner::AllocationTarget::Device,
 	       NCOARSE, NCOARSE, NCOARSE, NIDX, NCOARSE);
     
@@ -230,11 +229,11 @@ TEST_CASE( "DataBox interpolation", "[DataBox]" ) {
     db.setRange(3, xmin, xmax, NCOARSE);
     db.setRange(4, xmin, xmax, NCOARSE);
     portableFor("Fill 5D databox",
-		0, NCOARSE, 0, NCOARSE, 0, NCOARSE, 0, NIDX, 0, NCOARSE
+		0, NCOARSE, 0, NCOARSE, 0, NCOARSE, 0, NIDX, 0, NCOARSE,
 		PORTABLE_LAMBDA(const int ib, const int ia,
 				const int iz, const int iy, const int ix) {
 		  RegularGrid1D grid(xmin,xmax,NCOARSE);
-		  Real b = grid.x(ib)
+		  Real b = grid.x(ib);
 		  Real a = grid.x(ia);
 		  Real z = grid.x(iz);
 		  Real y = grid.x(iy);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

For `singularity-opac`, I need the capability to perform interpolation of the form:
```C++
Real v = db.interpToReal(x4, x3, x2, j, x1)
```
where `x1`, `x2`, `x3`, and `x4` are real numbers that are interpolated on and `j` is an integer that's indexed on. This is a common pattern for multi-species transport such as neutrino transport. I don't expect it's needed outside of neutrino transport, but you never know.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.

