### PR TITLE
First commit to cleanup attributes and add forceinline to portable ar…

### DIFF
--- a/databox.hpp
+++ b/databox.hpp
@@ -56,8 +56,8 @@ class DataBox {
   // example call
   // DataBox(data, nx3, nx2, nx1)
   template <typename... Args>
-  PORTABLE_INLINE_FUNCTION __attribute__((nothrow))
-  DataBox(Real *data, Args... args)
+  PORTABLE_INLINE_FUNCTION
+  DataBox(Real *data, Args... args) noexcept
       : rank_(sizeof...(args)), status_(DataStatus::Unmanaged), data_(data) {
     dataView_.NewPortableMDArray(data, std::forward<Args>(args)...);
     setAllIndexed_();
@@ -68,28 +68,28 @@ class DataBox {
   // example call
   // DataBox(data, nx3, nx2, nx1)
   template <typename... Args>
-  inline __attribute__((nothrow)) DataBox(AllocationTarget t, Args... args)
+  inline DataBox(AllocationTarget t, Args... args) noexcept
       : rank_(sizeof...(args)) {
     allocate_(t, std::forward<Args>(args)...);
     dataView_.NewPortableMDArray(data_, std::forward<Args>(args)...);
     setAllIndexed_();
   }
   template <typename... Args>
-  inline __attribute__((nothrow)) DataBox(Args... args)
+  inline DataBox(Args... args) noexcept
       : DataBox(AllocationTarget::Host, std::forward<Args>(args)...) {}
 
   // Copy and move constructors. All shallow.
-  inline __attribute__((nothrow)) DataBox(PortableMDArray<Real> A)
+  inline DataBox(PortableMDArray<Real> A) noexcept
       : rank_(A.GetRank()), status_(DataStatus::Unmanaged), data_(A.data()),
         dataView_(A) {
     setAllIndexed_();
   }
-  inline __attribute__((nothrow)) DataBox(PortableMDArray<Real> &A)
+  inline DataBox(PortableMDArray<Real> &A) noexcept
       : rank_(A.GetRank()), status_(DataStatus::Unmanaged), data_(A.data()),
         dataView_(A) {
     setAllIndexed_();
   }
-  PORTABLE_INLINE_FUNCTION __attribute__((nothrow)) DataBox(const DataBox &src)
+  PORTABLE_INLINE_FUNCTION DataBox(const DataBox &src) noexcept
       : rank_(src.rank_), status_(src.status_), data_(src.data_) {
     setAllIndexed_();
     dataView_.InitWithShallowSlice(src.dataView_, 6, 0, src.dim(6));
@@ -100,8 +100,9 @@ class DataBox {
   }
 
   // Slice constructor
-  PORTABLE_INLINE_FUNCTION __attribute__((nothrow))
+  PORTABLE_INLINE_FUNCTION
   DataBox(const DataBox &b, const int dim, const int indx, const int nvar)
+  noexcept
       : status_(DataStatus::Unmanaged), data_(b.data_) {
     dataView_.InitWithShallowSlice(b.dataView_, dim, indx, nvar);
     rank_ = dataView_.GetRank();
@@ -168,30 +169,25 @@ class DataBox {
 
   // Interpolates whole DataBox to a real number,
   // x1 is fastest index. xN is slowest.
-  PORTABLE_INLINE_FUNCTION Real __attribute__((nothrow))
-  __attribute__((always_inline)) interpToReal(const Real x) const;
-  PORTABLE_INLINE_FUNCTION Real __attribute__((nothrow))
-  __attribute__((always_inline))
-  interpToReal(const Real x2, const Real x1) const;
-  PORTABLE_INLINE_FUNCTION Real __attribute__((nothrow))
-  __attribute__((always_inline))
-  interpToReal(const Real x3, const Real x2, const Real x1) const;
-  PORTABLE_INLINE_FUNCTION Real __attribute__((nothrow))
-  __attribute__((always_inline))
+  PORTABLE_FORCEINLINE_FUNCTION Real
+  interpToReal(const Real x) const noexcept;
+  PORTABLE_FORCEINLINE_FUNCTION Real
+  interpToReal(const Real x2, const Real x1) const noexcept;
+  PORTABLE_FORCEINLINE_FUNCTION Real
+  interpToReal(const Real x3, const Real x2, const Real x1) const noexcept;
+  PORTABLE_FORCEINLINE_FUNCTION Real
   interpToReal(const Real x3, const Real x2, const Real x1,
-               const int idx) const;
-  PORTABLE_INLINE_FUNCTION Real __attribute__((nothrow))
-  __attribute__((always_inline))
+               const int idx) const noexcept;
+  PORTABLE_FORCEINLINE_FUNCTION Real
   interpToReal(const Real x4, const Real x3, const Real x2,
-               const Real x1) const;
+               const Real x1) const noexcept;
   // Interpolates the whole databox to a real number,
   // with one intermediate, non-interpolatable index,
   // which is simply indexed into
   // JMM: Trust me---this is a common pattern
-  PORTABLE_INLINE_FUNCTION Real __attribute__((nothrow))
-  __attribute__((always_inline))
+  PORTABLE_FORCEINLINE_FUNCTION Real
   interpToReal(const Real x4, const Real x3, const Real x2, const int idx,
-               const Real x1) const;
+               const Real x1) const noexcept;
   // Interpolates SLOWEST indices of databox to a new
   // DataBox, interpolated at that slowest index.
   // WARNING: requires memory to be pre-allocated.
@@ -388,9 +384,8 @@ PORTABLE_INLINE_FUNCTION Real DataBox::interpToReal(const Real x) const {
   return grids_[0](x, dataView_);
 }
 
-PORTABLE_INLINE_FUNCTION Real __attribute__((nothrow))
-__attribute__((always_inline))
-DataBox::interpToReal(const Real x2, const Real x1) const {
+PORTABLE_FORCEINLINE_FUNCTION Real
+DataBox::interpToReal(const Real x2, const Real x1) const noexcept {
   assert(canInterpToReal_(2));
   int ix1, ix2;
   weights_t w1, w2;
@@ -404,9 +399,9 @@ DataBox::interpToReal(const Real x2, const Real x1) const {
                    w1[1] * dataView_(ix2 + 1, ix1 + 1)));
 }
 
-PORTABLE_INLINE_FUNCTION Real __attribute__((nothrow))
-__attribute__((always_inline))
-DataBox::interpToReal(const Real x3, const Real x2, const Real x1) const {
+PORTABLE_FORCEINLINE_FUNCTION Real
+DataBox::interpToReal(const Real x3, const Real x2,
+                      const Real x1) const noexcept {
   assert(canInterpToReal_(3));
   int ix[3];
   weights_t w[3];
@@ -427,10 +422,9 @@ DataBox::interpToReal(const Real x3, const Real x2, const Real x1) const {
                       w[0][1] * dataView_(ix[2] + 1, ix[1] + 1, ix[0] + 1))));
 }
 
-PORTABLE_INLINE_FUNCTION Real __attribute__((nothrow))
-__attribute__((always_inline))
+PORTABLE_FORCEINLINE_FUNCTION Real
 DataBox::interpToReal(const Real x3, const Real x2, const Real x1,
-                      const int idx) const {
+                      const int idx) const noexcept {
   assert(rank_ == 4);
   for (int r = 1; r < rank_; ++r) {
     assert(indices_[r] == IndexType::Interpolated);
@@ -457,10 +451,11 @@ DataBox::interpToReal(const Real x3, const Real x2, const Real x1,
                 w[0][1] * dataView_(ix[2] + 1, ix[1] + 1, ix[0] + 1, idx))));
 }
 
-PORTABLE_INLINE_FUNCTION Real __attribute__((nothrow))
-__attribute__((always_inline))
+// DH: this is a large function to force an inline, perhaps just make it a 
+// suggestion to the compiler?
+PORTABLE_FORCEINLINE_FUNCTION Real
 DataBox::interpToReal(const Real x4, const Real x3, const Real x2,
-                      const Real x1) const {
+                      const Real x1) const noexcept {
   assert(canInterpToReal_(4));
   Real x[] = {x1, x2, x3, x4};
   int ix[4];
@@ -509,10 +504,9 @@ DataBox::interpToReal(const Real x4, const Real x3, const Real x2,
   );
 }
 
-PORTABLE_INLINE_FUNCTION Real __attribute__((nothrow))
-__attribute__((always_inline))
+PORTABLE_FORCEINLINE_FUNCTION Real
 DataBox::interpToReal(const Real x4, const Real x3, const Real x2,
-                      const int idx, const Real x1) const {
+                      const int idx, const Real x1) const noexcept {
   assert(rank_ == 5);
   assert(indices_[0] == IndexType::Interpolated);
   assert(grids_[0].isWellFormed());

--- a/databox.hpp
+++ b/databox.hpp
@@ -379,7 +379,8 @@ inline void DataBox::resize(AllocationTarget t, Args... args) {
   dataView_.NewPortableMDArray(data_, std::forward<Args>(args)...);
 }
 
-PORTABLE_INLINE_FUNCTION Real DataBox::interpToReal(const Real x) const {
+PORTABLE_INLINE_FUNCTION Real DataBox::interpToReal(const Real x)
+const noexcept {
   assert(canInterpToReal_(1));
   return grids_[0](x, dataView_);
 }

--- a/ports-of-call/portability.hpp
+++ b/ports-of-call/portability.hpp
@@ -22,6 +22,7 @@
 #include "Kokkos_Core.hpp"
 #define PORTABLE_FUNCTION KOKKOS_FUNCTION
 #define PORTABLE_INLINE_FUNCTION KOKKOS_INLINE_FUNCTION
+#define PORTABLE_FORCEINLINE_FUNCTION KOKKOS_FORCEINLINE_FUNCTION
 #define PORTABLE_LAMBDA KOKKOS_LAMBDA
 #define _WITH_KOKKOS_
 // The following is a malloc on default memory space
@@ -33,6 +34,8 @@
 #include "cuda.h"
 #define PORTABLE_FUNCTION __host__ __device__
 #define PORTABLE_INLINE_FUNCTION __host__ __device__ inline
+#define PORTABLE_FORCEINLINE_FUNCTION \
+__host__ __device__ inline __attribute__((always_inline))
 #define PORTABLE_LAMBDA [=] __host__ __device__
 void *PORTABLE_MALLOC(size_t size) {
   void *devPtr cudaError_t e = cudaMalloc(devPtr, size);
@@ -46,6 +49,7 @@ void PORTABLE_FREE(void *ptr) { cudaError_t e = cudaFree(ptr); }
 #else
 #define PORTABLE_FUNCTION
 #define PORTABLE_INLINE_FUNCTION inline
+#define PORTABLE_FORCEINLINE_FUNCTION inline __attribute__((always_inline))
 #define PORTABLE_LAMBDA [=]
 #define PORTABLE_MALLOC(size) malloc(size)
 #define PORTABLE_FREE(ptr) free(ptr)

--- a/ports-of-call/portable_arrays.hpp
+++ b/ports-of-call/portable_arrays.hpp
@@ -38,64 +38,65 @@ class PortableMDArray {
 
   // ctors
   // default ctor: simply set null PortableMDArray
-  PORTABLE_INLINE_FUNCTION
-  PortableMDArray()
+  PORTABLE_FUNCTION
+  PortableMDArray() noexcept
       : pdata_(nullptr), nx1_(0), nx2_(0), nx3_(0), nx4_(0), nx5_(0), nx6_(0) {}
-  PORTABLE_FUNCTION __attribute__((nothrow)) PortableMDArray(T *data, int nx1)
+  PORTABLE_FUNCTION PortableMDArray(T *data, int nx1) noexcept
       : pdata_(data), nx1_(nx1), nx2_(1), nx3_(1), nx4_(1), nx5_(1), nx6_(1) {}
-  PORTABLE_FUNCTION __attribute__((nothrow))
-  PortableMDArray(T *data, int nx2, int nx1)
+  PORTABLE_FUNCTION
+  PortableMDArray(T *data, int nx2, int nx1) noexcept
       : pdata_(data), nx1_(nx1), nx2_(nx2), nx3_(1), nx4_(1), nx5_(1), nx6_(1) {
   }
-  PORTABLE_FUNCTION __attribute__((nothrow))
-  PortableMDArray(T *data, int nx3, int nx2, int nx1)
+  PORTABLE_FUNCTION
+  PortableMDArray(T *data, int nx3, int nx2, int nx1) noexcept
       : pdata_(data), nx1_(nx1), nx2_(nx2), nx3_(nx3), nx4_(1), nx5_(1),
         nx6_(1) {}
-  PORTABLE_FUNCTION __attribute__((nothrow))
-  PortableMDArray(T *data, int nx4, int nx3, int nx2, int nx1)
+  PORTABLE_FUNCTION
+  PortableMDArray(T *data, int nx4, int nx3, int nx2, int nx1) noexcept
       : pdata_(data), nx1_(nx1), nx2_(nx2), nx3_(nx3), nx4_(nx4), nx5_(1),
         nx6_(1) {}
-  PORTABLE_FUNCTION __attribute__((nothrow))
-  PortableMDArray(T *data, int nx5, int nx4, int nx3, int nx2, int nx1)
+  PORTABLE_FUNCTION
+  PortableMDArray(T *data, int nx5, int nx4, int nx3, int nx2, int nx1) noexcept
       : pdata_(data), nx1_(nx1), nx2_(nx2), nx3_(nx3), nx4_(nx4), nx5_(nx5),
         nx6_(1) {}
-  PORTABLE_FUNCTION __attribute__((nothrow))
+  PORTABLE_FUNCTION
   PortableMDArray(T *data, int nx6, int nx5, int nx4, int nx3, int nx2, int nx1)
+  noexcept
       : pdata_(data), nx1_(nx1), nx2_(nx2), nx3_(nx3), nx4_(nx4), nx5_(nx5),
         nx6_(nx6) {}
 
   // define copy constructor and overload assignment operator so both do deep
   // copies.
-  __attribute__((nothrow)) PortableMDArray(const PortableMDArray<T> &t);
-  __attribute__((nothrow)) PortableMDArray<T> &
-  operator=(const PortableMDArray<T> &t);
+  PortableMDArray(const PortableMDArray<T> &t) noexcept;
+  PortableMDArray<T> &
+  operator=(const PortableMDArray<T> &t) noexcept;
 
   // public functions to allocate/deallocate memory for 1D-5D data
-  PORTABLE_FUNCTION __attribute__((nothrow)) void NewPortableMDArray(T *data,
-                                                                     int nx1);
-  PORTABLE_FUNCTION __attribute__((nothrow)) void
-  NewPortableMDArray(T *data, int nx2, int nx1);
-  PORTABLE_FUNCTION __attribute__((nothrow)) void
-  NewPortableMDArray(T *data, int nx3, int nx2, int nx1);
-  PORTABLE_FUNCTION __attribute__((nothrow)) void
-  NewPortableMDArray(T *data, int nx4, int nx3, int nx2, int nx1);
-  PORTABLE_FUNCTION __attribute__((nothrow)) void
-  NewPortableMDArray(T *data, int nx5, int nx4, int nx3, int nx2, int nx1);
-  PORTABLE_FUNCTION __attribute__((nothrow)) void
+  PORTABLE_FUNCTION void NewPortableMDArray(T *data, int nx1) noexcept;
+  PORTABLE_FUNCTION void
+  NewPortableMDArray(T *data, int nx2, int nx1) noexcept;
+  PORTABLE_FUNCTION void
+  NewPortableMDArray(T *data, int nx3, int nx2, int nx1) noexcept;
+  PORTABLE_FUNCTION void
+  NewPortableMDArray(T *data, int nx4, int nx3, int nx2, int nx1) noexcept;
+  PORTABLE_FUNCTION void
+  NewPortableMDArray(T *data, int nx5, int nx4, int nx3, int nx2,
+                     int nx1) noexcept;
+  PORTABLE_FUNCTION void
   NewPortableMDArray(T *data, int nx6, int nx5, int nx4, int nx3, int nx2,
-                     int nx1);
+                     int nx1) noexcept;
 
   // public function to swap underlying data pointers of two equally-sized
   // arrays
   void SwapPortableMDArray(PortableMDArray<T> &array2);
 
   // functions to get array dimensions
-  PORTABLE_INLINE_FUNCTION int GetDim1() const { return nx1_; }
-  PORTABLE_INLINE_FUNCTION int GetDim2() const { return nx2_; }
-  PORTABLE_INLINE_FUNCTION int GetDim3() const { return nx3_; }
-  PORTABLE_INLINE_FUNCTION int GetDim4() const { return nx4_; }
-  PORTABLE_INLINE_FUNCTION int GetDim5() const { return nx5_; }
-  PORTABLE_INLINE_FUNCTION int GetDim6() const { return nx6_; }
+  PORTABLE_FORCEINLINE_FUNCTION int GetDim1() const { return nx1_; }
+  PORTABLE_FORCEINLINE_FUNCTION int GetDim2() const { return nx2_; }
+  PORTABLE_FORCEINLINE_FUNCTION int GetDim3() const { return nx3_; }
+  PORTABLE_FORCEINLINE_FUNCTION int GetDim4() const { return nx4_; }
+  PORTABLE_FORCEINLINE_FUNCTION int GetDim5() const { return nx5_; }
+  PORTABLE_FORCEINLINE_FUNCTION int GetDim6() const { return nx6_; }
   PORTABLE_INLINE_FUNCTION int GetDim(size_t i) const {
     // TODO: remove if performance cirtical
     assert(0 < i && i <= 6 && "PortableMDArrays are max 6D");
@@ -117,10 +118,10 @@ class PortableMDArray {
   }
 
   // a function to get the total size of the array
-  PORTABLE_INLINE_FUNCTION int GetSize() const {
+  PORTABLE_FORCEINLINE_FUNCTION int GetSize() const {
     return nx1_ * nx2_ * nx3_ * nx4_ * nx5_ * nx6_;
   }
-  PORTABLE_INLINE_FUNCTION std::size_t GetSizeInBytes() const {
+  PORTABLE_FORCEINLINE_FUNCTION std::size_t GetSizeInBytes() const {
     return nx1_ * nx2_ * nx3_ * nx4_ * nx5_ * nx6_ * sizeof(T);
   }
 
@@ -158,17 +159,17 @@ class PortableMDArray {
     Reshape(1, 1, 1, 1, 1, nx1);
   }
 
-  PORTABLE_INLINE_FUNCTION bool IsShallowSlice() { return true; }
-  PORTABLE_INLINE_FUNCTION bool IsEmpty() { return GetSize() < 1; }
+  PORTABLE_FORCEINLINE_FUNCTION bool IsShallowSlice() { return true; }
+  PORTABLE_FORCEINLINE_FUNCTION bool IsEmpty() { return GetSize() < 1; }
   // "getter" function to access private data member
   // TODO(felker): Replace this unrestricted "getter" with a limited, safer
   // alternative.
   // TODO(felker): Rename function. Conflicts with "PortableMDArray<> data"
   // OutputData member.
-  PORTABLE_INLINE_FUNCTION T *data() { return pdata_; }
-  PORTABLE_INLINE_FUNCTION const T *data() const { return pdata_; }
-  PORTABLE_INLINE_FUNCTION T *begin() { return pdata_; }
-  PORTABLE_INLINE_FUNCTION T *end() { return pdata_ + GetSize(); }
+  PORTABLE_FORCEINLINE_FUNCTION T *data() { return pdata_; }
+  PORTABLE_FORCEINLINE_FUNCTION const T *data() const { return pdata_; }
+  PORTABLE_FORCEINLINE_FUNCTION T *begin() { return pdata_; }
+  PORTABLE_FORCEINLINE_FUNCTION T *end() { return pdata_ + GetSize(); }
 
   // overload "function call" operator() to access 1d-5d data
   // provides Fortran-like syntax for multidimensional arrays vs. "subscript"
@@ -177,56 +178,58 @@ class PortableMDArray {
   // "non-const variants" called for "PortableMDArray<T>()" provide read/write
   // access via returning by reference, enabling assignment on returned l-value,
   // e.g.: a(3) = 3.0;
-  PORTABLE_INLINE_FUNCTION T &operator()() { return pdata_[0]; }
+  PORTABLE_FORCEINLINE_FUNCTION T &operator()() { return pdata_[0]; }
 
-  PORTABLE_INLINE_FUNCTION T &operator()(const int n) { return pdata_[n]; }
+  PORTABLE_FORCEINLINE_FUNCTION T &operator()(const int n) { return pdata_[n]; }
   // "const variants" called for "const PortableMDArray<T>" returns T by value,
   // since T is typically a built-in type (versus "const T &" to avoid copying
   // for general types)
-  PORTABLE_INLINE_FUNCTION T &operator()() const { return pdata_[0]; }
-  PORTABLE_INLINE_FUNCTION T &operator()(const int n) const {
+  PORTABLE_FORCEINLINE_FUNCTION T &operator()() const { return pdata_[0]; }
+  PORTABLE_FORCEINLINE_FUNCTION T &operator()(const int n) const {
     return pdata_[n];
   }
-  PORTABLE_INLINE_FUNCTION T &operator()(const int n, const int i) {
+  PORTABLE_FORCEINLINE_FUNCTION T &operator()(const int n, const int i) {
     return pdata_[i + nx1_ * n];
   }
-  PORTABLE_INLINE_FUNCTION T &operator()(const int n, const int i) const {
+  PORTABLE_FORCEINLINE_FUNCTION T &operator()(const int n, const int i) const {
     return pdata_[i + nx1_ * n];
   }
-  PORTABLE_INLINE_FUNCTION T &operator()(const int n, const int j,
-                                         const int i) {
+  PORTABLE_FORCEINLINE_FUNCTION T &operator()(const int n, const int j,
+                                              const int i) {
     return pdata_[i + nx1_ * (j + nx2_ * n)];
   }
-  PORTABLE_INLINE_FUNCTION T &operator()(const int n, const int j,
-                                         const int i) const {
+  PORTABLE_FORCEINLINE_FUNCTION T &operator()(const int n, const int j,
+                                              const int i) const {
     return pdata_[i + nx1_ * (j + nx2_ * n)];
   }
-  PORTABLE_INLINE_FUNCTION T &operator()(const int n, const int k, const int j,
-                                         const int i) {
+  PORTABLE_FORCEINLINE_FUNCTION T &operator()(const int n, const int k,
+                                              const int j, const int i) {
     return pdata_[i + nx1_ * (j + nx2_ * (k + nx3_ * n))];
   }
-  PORTABLE_INLINE_FUNCTION T &operator()(const int n, const int k, const int j,
-                                         const int i) const {
+  PORTABLE_FORCEINLINE_FUNCTION T &operator()(const int n, const int k,
+                                              const int j, const int i) const {
     return pdata_[i + nx1_ * (j + nx2_ * (k + nx3_ * n))];
   }
-  PORTABLE_INLINE_FUNCTION T &operator()(const int m, const int n, const int k,
-                                         const int j, const int i) {
+  PORTABLE_FORCEINLINE_FUNCTION T &operator()(const int m, const int n,
+                                              const int k, const int j,
+                                              const int i) {
     return pdata_[i + nx1_ * (j + nx2_ * (k + nx3_ * (n + nx4_ * m)))];
   }
-  PORTABLE_INLINE_FUNCTION T &operator()(const int m, const int n, const int k,
-                                         const int j, const int i) const {
+  PORTABLE_FORCEINLINE_FUNCTION T &operator()(const int m, const int n,
+                                              const int k, const int j,
+                                              const int i) const {
     return pdata_[i + nx1_ * (j + nx2_ * (k + nx3_ * (n + nx4_ * m)))];
   }
   // int l?, int o?
-  PORTABLE_INLINE_FUNCTION T &operator()(const int p, const int m, const int n,
-                                         const int k, const int j,
-                                         const int i) {
+  PORTABLE_FORCEINLINE_FUNCTION T &operator()(const int p, const int m,
+                                              const int n, const int k,
+                                              const int j, const int i) {
     return pdata_[i +
                   nx1_ * (j + nx2_ * (k + nx3_ * (n + nx4_ * (m + nx5_ * p))))];
   }
-  PORTABLE_INLINE_FUNCTION T &operator()(const int p, const int m, const int n,
-                                         const int k, const int j,
-                                         const int i) const {
+  PORTABLE_FORCEINLINE_FUNCTION T &operator()(const int p, const int m,
+                                              const int n, const int k,
+                                              const int j, const int i) const {
     return pdata_[i +
                   nx1_ * (j + nx2_ * (k + nx3_ * (n + nx4_ * (m + nx5_ * p))))];
   }
@@ -271,8 +274,7 @@ class PortableMDArray {
 // copy constructor (does a shallow copy)
 
 template <typename T>
-__attribute__((nothrow))
-PortableMDArray<T>::PortableMDArray(const PortableMDArray<T> &src) {
+PortableMDArray<T>::PortableMDArray(const PortableMDArray<T> &src) noexcept {
   nx1_ = src.nx1_;
   nx2_ = src.nx2_;
   nx3_ = src.nx3_;
@@ -285,8 +287,8 @@ PortableMDArray<T>::PortableMDArray(const PortableMDArray<T> &src) {
 // shallow copy assignment operator
 
 template <typename T>
-__attribute__((nothrow)) PortableMDArray<T> &
-PortableMDArray<T>::operator=(const PortableMDArray<T> &src) {
+PortableMDArray<T> &
+PortableMDArray<T>::operator=(const PortableMDArray<T> &src) noexcept {
   if (this != &src) {
     nx1_ = src.nx1_;
     nx2_ = src.nx2_;
@@ -380,8 +382,8 @@ PortableMDArray<T>::InitWithShallowSlice(const PortableMDArray<T> &src,
 //  \brief allocate new 1D array with elements initialized to zero.
 
 template <typename T>
-PORTABLE_FUNCTION __attribute__((nothrow)) void
-PortableMDArray<T>::NewPortableMDArray(T *data, int nx1) {
+PORTABLE_FUNCTION void
+PortableMDArray<T>::NewPortableMDArray(T *data, int nx1) noexcept {
   nx1_ = nx1;
   nx2_ = 1;
   nx3_ = 1;
@@ -396,8 +398,8 @@ PortableMDArray<T>::NewPortableMDArray(T *data, int nx1) {
 //  \brief 2d data allocation
 
 template <typename T>
-PORTABLE_FUNCTION __attribute__((nothrow)) void
-PortableMDArray<T>::NewPortableMDArray(T *data, int nx2, int nx1) {
+PORTABLE_FUNCTION void
+PortableMDArray<T>::NewPortableMDArray(T *data, int nx2, int nx1) noexcept {
   nx1_ = nx1;
   nx2_ = nx2;
   nx3_ = 1;
@@ -412,8 +414,9 @@ PortableMDArray<T>::NewPortableMDArray(T *data, int nx2, int nx1) {
 //  \brief 3d data allocation
 
 template <typename T>
-PORTABLE_FUNCTION __attribute__((nothrow)) void
-PortableMDArray<T>::NewPortableMDArray(T *data, int nx3, int nx2, int nx1) {
+PORTABLE_FUNCTION void
+PortableMDArray<T>::NewPortableMDArray(T *data, int nx3, int nx2, int nx1)
+noexcept {
   nx1_ = nx1;
   nx2_ = nx2;
   nx3_ = nx3;
@@ -428,9 +431,9 @@ PortableMDArray<T>::NewPortableMDArray(T *data, int nx3, int nx2, int nx1) {
 //  \brief 4d data allocation
 
 template <typename T>
-PORTABLE_FUNCTION __attribute__((nothrow)) void
+PORTABLE_FUNCTION void
 PortableMDArray<T>::NewPortableMDArray(T *data, int nx4, int nx3, int nx2,
-                                       int nx1) {
+                                       int nx1) noexcept {
   nx1_ = nx1;
   nx2_ = nx2;
   nx3_ = nx3;
@@ -445,9 +448,9 @@ PortableMDArray<T>::NewPortableMDArray(T *data, int nx4, int nx3, int nx2,
 //  \brief 5d data allocation
 
 template <typename T>
-PORTABLE_FUNCTION __attribute__((nothrow)) void
+PORTABLE_FUNCTION void
 PortableMDArray<T>::NewPortableMDArray(T *data, int nx5, int nx4, int nx3,
-                                       int nx2, int nx1) {
+                                       int nx2, int nx1) noexcept {
   nx1_ = nx1;
   nx2_ = nx2;
   nx3_ = nx3;
@@ -462,9 +465,9 @@ PortableMDArray<T>::NewPortableMDArray(T *data, int nx5, int nx4, int nx3,
 //  \brief 6d data allocation
 
 template <typename T>
-PORTABLE_FUNCTION __attribute__((nothrow)) void
+PORTABLE_FUNCTION void
 PortableMDArray<T>::NewPortableMDArray(T *data, int nx6, int nx5, int nx4,
-                                       int nx3, int nx2, int nx1) {
+                                       int nx3, int nx2, int nx1) noexcept {
   nx1_ = nx1;
   nx2_ = nx2;
   nx3_ = nx3;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -290,6 +290,7 @@ TEST_CASE("DataBox interpolation", "[DataBox]") {
           error);
       REQUIRE(error <= EPSTEST);
     }
+    free(db);
   }
 
   constexpr int NFINE = 100;


### PR DESCRIPTION
…ray call operator accessors.

Addresses issues #12 plus additional cleanup

## PR Summary
Eliminates the use of `__attribute__`s except in one macro definition.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code is formatted.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

