### PR TITLE
namespace formatting

### DIFF
--- a/cmake/Format.cmake
+++ b/cmake/Format.cmake
@@ -59,7 +59,7 @@ set(
 file(GLOB_RECURSE FORMAT_SOURCES CONFIGURE_DEPENDS ${GLOBS})
 
 if (CLANG_FORMAT)
-  add_custom_target(format
+  add_custom_target(format_spiner
     COMMAND ${CLANG_FORMAT} -i ${FORMAT_SOURCES}
     VERBATIM)
 endif()

--- a/doc/sphinx/src/building.rst
+++ b/doc/sphinx/src/building.rst
@@ -41,8 +41,8 @@ HDF5 is searched for and configured via the usual `cmake`_ machinery.
 
 .. _`cmake`: https://cmake.org/
 
-A ``format`` target is also added if ``clang-format`` is found, so
-that ``make format`` will auto-format the repository.
+A ``format_spiner`` target is also added if ``clang-format`` is found, so
+that ``make format_spiner`` will auto-format the repository.
 
 Testing is enabled via `Catch2`_, which is automatically downloaded
 during the cmake configure phase if needed.


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

This resolves an issue with in-tree builds, where multiple make format targets may be defined, and cause cmake errors. The simple solution is to namespace the format target. I will apply the same fix to `singularity-eos`.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code is formatted.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

