### PR TITLE
Sync spackages with spack upstream versions

### DIFF
--- a/spack-repo/packages/ports-of-call/package.py
+++ b/spack-repo/packages/ports-of-call/package.py
@@ -1,18 +1,26 @@
-# Spackage for Ports of Call
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
 
+
 class PortsOfCall(CMakePackage, CudaPackage):
-    """ports-of-call"""
+    """Ports of Call: Performance Portability Utilities"""
 
     homepage    = "https://github.com/lanl/ports-of-call"
-    url         = "https://github.com/lanl/ports-of-call/archive/refs/heads/main.zip"
-    git         = "git@github.com:lanl/ports-of-call.git"
+    url         = "https://github.com/lanl/ports-of-call/archive/refs/tags/v1.1.0.tar.gz"
+    git         = "https://github.com/lanl/ports-of-call.git"
+
+    maintainers = ['rbberger']
 
     version("main", branch="main")
+    version('1.1.0', sha256='c47f7e24c82176b69229a2bcb23a6adcf274dc90ec77a452a36ccae0b12e6e39')
+
     variant("doc", default=False, description="Sphinx Documentation Support")
     variant("portability_strategy", description="Portability strategy backend",
-            values=("Kokkos","Cuda","None"),multi=False,default="None")
+            values=("Kokkos", "Cuda", "None"), multi=False, default="None")
 
     depends_on("cmake@3.12:")
 

--- a/spack-repo/packages/spiner/package.py
+++ b/spack-repo/packages/spiner/package.py
@@ -1,15 +1,23 @@
-# Spackage for Spiner
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
 
+
 class Spiner(CMakePackage, CudaPackage):
-    """Spiner"""
+    """Spiner:
+    Performance portable routines for generic, tabulated, multi-dimensional data"""
 
     homepage    = "https://github.com/lanl/spiner"
-    url         = "https://github.com/lanl/spiner/archive/refs/heads/main.zip"
-    git         = "git@github.com:lanl/spiner.git"
+    url         = "https://github.com/lanl/spiner/archive/refs/tags/1.4.0.tar.gz"
+    git         = "https://github.com/lanl/spiner.git"
+
+    maintainers = ['rbberger']
 
     version("main", branch="main")
+    version('1.4.0', sha256='c3801b9eab26feabec33ff8c59e4056f384287f407d23faba010d354766f3ac5')
 
     # When overriding/overloading varaints, the last variant is always used, except for
     # "when" clauses. Therefore, call the whens FIRST then the non-whens.
@@ -26,15 +34,16 @@ class Spiner(CMakePackage, CudaPackage):
 
     depends_on("cmake@3.12:")
     depends_on("catch2@2.13.4:2.13.6")
+    depends_on("ports-of-call@1.1.0:")
 
     # Currently the raw cuda backend of ports-of-call is not supported.
     depends_on("ports-of-call portability_strategy=Kokkos", when="+kokkos")
     depends_on("ports-of-call portability_strategy=None", when="~kokkos")
     for _flag in list(CudaPackage.cuda_arch_values):
-        depends_on("kokkos@3.2.00 cuda_arch=" + _flag, when="+cuda+kokkos cuda_arch=" + _flag)
+        depends_on("kokkos@3.2.00: cuda_arch=" + _flag, when="+cuda+kokkos cuda_arch=" + _flag)
     for _flag in ("~cuda", "+cuda", "~openmp", "+openmp"):
-        depends_on("kokkos@3.2.00" + _flag, when="+kokkos" + _flag)
-    depends_on("kokkos@3.2.00~shared+wrapper+cuda_lambda+cuda_relocatable_device_code", when="+cuda+kokkos")
+        depends_on("kokkos@3.2.00: " + _flag, when="+kokkos" + _flag)
+    depends_on("kokkos@3.2.00: ~shared+wrapper+cuda_lambda+cuda_relocatable_device_code", when="+cuda+kokkos")
 
     depends_on("hdf5+hl~mpi", when="+hdf5~mpi")
     depends_on("hdf5+hl+mpi", when="+hdf5+mpi")
@@ -56,9 +65,13 @@ class Spiner(CMakePackage, CudaPackage):
 
     def cmake_args(self):
         args = [
-            "-DBUILD_TESTING={0}".format("ON" if self.run_tests else "OFF"),
-            self.define_from_variant("SPINER_USE_KOKKOS","kokkos"),
-            self.define_from_variant("SPINER_USE_CUDA","cuda"),
+            self.define("BUILD_TESTING", self.run_tests),
+            self.define_from_variant("SPINER_USE_KOKKOS", "kokkos"),
+            self.define_from_variant("SPINER_USE_CUDA", "cuda"),
             self.define_from_variant("SPINER_USE_HDF", "hdf5")
         ]
+        if '+cuda' in self.spec:
+            args.append(self.define(
+                'CMAKE_CUDA_ARCHITECTURES', self.spec.variants['cuda_arch'].value
+            ))
         return args


### PR DESCRIPTION
## PR Summary

Update Spack packages for `ports-of-call` and `Spiner` to the ones now present in Spack upstream

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code is formatted.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

