### PR TITLE
Let ports of call do its own portability settings

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,6 +148,7 @@ before_script:
     - |
       cmake -DBUILD_TESTING=ON \
             -DCMAKE_INSTALL_PREFIX=${CI_PROJECT_DIR}/install \
+            -DSPINER_FORCE_INTERNAL_PORTS=ON \
             -DSPINER_USE_HDF=ON \
             -DSPINER_USE_KOKKOS=$([[ ${CI_JOB_NAME} =~ "power9" ]] && echo ON || echo OFF) \
             -DSPINER_USE_CUDA=$([[ ${CI_JOB_NAME} =~ "power9" ]] && echo ON || echo OFF) \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -154,7 +154,7 @@ before_script:
             -DSPINER_USE_CUDA=$([[ ${CI_JOB_NAME} =~ "power9" ]] && echo ON || echo OFF) \
             -DCMAKE_CXX_COMPILER=$([[ ${CI_JOB_NAME} =~ "power9" ]] && echo nvcc_wrapper || g++) \
             ..
-    - VERBOSE=1 make -j
+    - make -j
     - make install
     - make test
     - make convergence

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,7 +148,6 @@ before_script:
     - |
       cmake -DBUILD_TESTING=ON \
             -DCMAKE_INSTALL_PREFIX=${CI_PROJECT_DIR}/install \
-            -DSPINER_FORCE_INTERNAL_PORTS=ON \
             -DSPINER_USE_HDF=ON \
             -DSPINER_USE_KOKKOS=$([[ ${CI_JOB_NAME} =~ "power9" ]] && echo ON || echo OFF) \
             -DSPINER_USE_CUDA=$([[ ${CI_JOB_NAME} =~ "power9" ]] && echo ON || echo OFF) \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ if(SPINER_USE_HDF)
 endif()
 
 if (SPINER_USE_KOKKOS)
-  set(PORTABILITY_STRATEGY "Kokkos" STRING CACHE "Portability strategy" FORCE)
+  set(PORTABILITY_STRATEGY "Kokkos" CACHE STRING "Portability strategy" FORCE)
   # Import Kokkos if not already available as a build target
   if (NOT TARGET Kokkos::kokkos)
     if (SPINER_USE_KOKKOS_SRC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,9 @@ if(SPINER_USE_HDF)
 endif()
 
 if (SPINER_USE_KOKKOS)
-  target_compile_definitions(${SPLIB} INTERFACE
-    PORTABILITY_STRATEGY_KOKKOS)
+  set(PORTABILITY_STRATEGY_KOKKOS)
+  # target_compile_definitions(${SPLIB} INTERFACE
+  #   PORTABILITY_STRATEGY_KOKKOS)
   # Import Kokkos if not already available as a build target
   if (NOT TARGET Kokkos::kokkos)
     if (SPINER_USE_KOKKOS_SRC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ if(SPINER_USE_HDF)
 endif()
 
 if (SPINER_USE_KOKKOS)
-  set(PORTABILITY_STRATEGY_KOKKOS)
+  set(PORTABILITY_STRATEGY "Kokkos" STRING CACHE "Portability strategy" FORCE)
   # Import Kokkos if not already available as a build target
   if (NOT TARGET Kokkos::kokkos)
     if (SPINER_USE_KOKKOS_SRC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,8 +84,6 @@ endif()
 
 if (SPINER_USE_KOKKOS)
   set(PORTABILITY_STRATEGY_KOKKOS)
-  # target_compile_definitions(${SPLIB} INTERFACE
-  #   PORTABILITY_STRATEGY_KOKKOS)
   # Import Kokkos if not already available as a build target
   if (NOT TARGET Kokkos::kokkos)
     if (SPINER_USE_KOKKOS_SRC)


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

The CI was failing because Spiner was using its own portability settings, rather than let `ports-of-call` handle it. This fixes that issue.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code is formatted.
- [x] Adds a test for any bugs fixed. Adds tests for new features.

