### PR TITLE
removed `export(PACKAGE)`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,5 +218,11 @@ else()
   # NOTE: This config will not be relocatable!
   export(TARGETS ${SPLIB} NAMESPACE ${SPLIB}::
     FILE "${CMAKE_CURRENT_BINARY_DIR}/${SPLIB}Targets.cmake")
-  export(PACKAGE ${SPLIB})
+  # see https://cmake.org/cmake/help/latest/policy/CMP0090.html
+  # since v3.15, this command is a no-op. prior, it populates
+  # the user package directory.
+  # `spiner` is commonly used "in-tree" downstream, so this 
+  # *may* confuse downstream builds that still search the 
+  # `~/.cmake` when doing `find_package()`
+  #  export(PACKAGE ${SPLIB})
 endif()


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Comments out `export(PACKAGE ...)`. As of `cmake@3.15`, this is a no-op. Prior versions will populate the user package registry (`~/.cmake`), which can confuse downstream builds. See https://cmake.org/cmake/help/latest/policy/CMP0090.html

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code is formatted.
- [x] Adds a test for any bugs fixed. Adds tests for new features.

