### PR TITLE
kokkos test support older kokkos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,6 @@ detail.  Why is this change required?  What problem does it solve?-->
 
 <!-- Note that some of these check boxes may not apply to all pull requests -->
 
-- [ ] Code is formatted.
+- [ ] Code is formatted. (You can use the format_spiner make target.)
 - [ ] Adds a test for any bugs fixed. Adds tests for new features.
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ workflow is used to check that code meets format requirements. We
 provide a make target in the build system. After configuration, simply
 type
 ```bash
-make format
+make format_spiner
 ```
 to format the code.
 

--- a/cmake/Format.cmake
+++ b/cmake/Format.cmake
@@ -54,6 +54,7 @@ set(
     ${PROJECT_SOURCE_DIR}/spiner/[^\.]*.cpp          ${PROJECT_SOURCE_DIR}/spiner/[^\.]*.hpp
     ${PROJECT_SOURCE_DIR}/ports-of-call/[^\.]*.cpp   ${PROJECT_SOURCE_DIR}/ports-of-call/[^\.]*.hpp
     ${PROJECT_SOURCE_DIR}/test/[^\.]*.cpp            ${PROJECT_SOURCE_DIR}/test/[^\.]*.hpp
+    ${PROJECT_SOURCE_DIR}/installtest/[^\.]*.cpp     ${PROJECT_SOURCE_DIR}/installtest/[^\.]*.hpp
 )
 
 file(GLOB_RECURSE FORMAT_SOURCES CONFIGURE_DEPENDS ${GLOBS})

--- a/installtest/libtest.cpp
+++ b/installtest/libtest.cpp
@@ -1,7 +1,7 @@
 // checks if compiler can find the poc header files
 #include <spiner/databox.hpp>
 
-int main(){
+int main() {
   // TODO: add some library checks
   return 0;
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -627,10 +627,10 @@ SCENARIO("DataBox HDF5", "[DataBox],[HDF5]") {
 
 #ifdef PORTABILITY_STRATEGY_KOKKOS
 SCENARIO("Kokkos functionality: interpolation", "[DataBox],[Kokkos]") {
-  constexpr int NFINE = 1000;
+  constexpr int NFINE = 100;
   constexpr int RANK = 3;
   constexpr int NZ = 8;
-  constexpr int NY = 10;
+  constexpr int NY = 9;
   constexpr int NX = 12;
   DataBox db(NZ, NY, NX);
 
@@ -645,7 +645,7 @@ SCENARIO("Kokkos functionality: interpolation", "[DataBox],[Kokkos]") {
                                            RegularGrid1D(ymin, ymax, NY),
                                            RegularGrid1D(zmin, zmax, NZ)};
 
-  Kokkos::View<RegularGrid1D*> fine_grids("fine grids", RANK);
+  Kokkos::View<RegularGrid1D *> fine_grids("fine grids", RANK);
   auto fine_grids_h = Kokkos::create_mirror_view(fine_grids);
   fine_grids_h[0] = RegularGrid1D(xmin, xmax, NFINE);
   fine_grids_h[1] = RegularGrid1D(ymin, ymax, NFINE);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

@ktsai7 pointed out a test was failing on Power9s. @rbberger found that the reason was that we are using an older Kokkos on that system, and it doesn't support `cuda-relaxed-constexpr`. The test relied on this to move a `std::array` to device via lambda capture.

This change removes the need for that, by instead using a `Kokkos::View`. I also got annoyed waiting for 1e9 points to be evaluated, so I reduce to 1e6 points.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code is formatted.
- [x] Adds a test for any bugs fixed. Adds tests for new features.

