### PR TITLE
CMake macros to functions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     tests:
       name: Run Unit and Regression Tests
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
 
       steps:
         - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     tests:
       name: Run Unit and Regression Tests
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-20.04
 
       steps:
         - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build
 bin
 CMakeFiles
 CMakeCache.txt
+CMakeUserPresets.json
 *.a
 a.out
 *.o

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ include(FetchContent)
 # to `find_package` before trying a download method
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
   set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE ALWAYS)
-  message(STATUS "FetchContent routines will try `find_package` first")
+  message(VERBOSE "FetchContent routines will try `find_package` first")
 else()
   message(DEPRECATION 
     "Detected cmake version (${CMAKE_VERSION}) older then 3.24. `spiner`"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # publicly and display publicly, and to permit others to do so.
 #------------------------------------------------------------------------------#
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.22)
 
 set(SPINER_VERSION 1.6.0)
 project(spiner VERSION ${SPINER_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,6 @@ else()
   )
 endif()
 
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
-
 # content is a wrapper to `FetchContent` calls
 include(content)
 spiner_content_declare(ports-of-call

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,6 @@ cmake_minimum_required(VERSION 3.22)
 set(SPINER_VERSION 1.6.0)
 project(spiner VERSION ${SPINER_VERSION})
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-
 # bring in some helpful CMake scripts 
 # make cache variables for install destinations
 include(GNUInstallDirs)
@@ -80,7 +78,7 @@ else()
 endif()
 
 # content is a wrapper to `FetchContent` calls
-include(content)
+include(cmake/content)
 spiner_content_declare(ports-of-call
   NAMESPACE spinerDeps
   GIT_REPO    https://github.com/lanl/ports-of-call

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,41 @@
+{
+  // the schema version (not spiner/cmake version)
+  "version": 3,
+  "configurePresets":[
+    {
+      "name": "default",
+      "hidden": true,
+      "cacheVariables":{
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "common",
+      "cacheVariables":{
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "SPINER_USE_HDF": true
+      }
+    },
+    {
+      "name": "testing-core",
+      "inherits": ["default"],
+      "cacheVariables":{
+        "BUILD_TESTING": true
+      }
+    },
+    {
+      "name": "testing-kokkos",
+      "inherits": ["testing-core"],
+      "cacheVariables":{
+        "SPINER_TEST_USE_KOKKOS": true
+      }
+    },
+    {
+      "name": "testing-kokkos-gpu",
+      "inherits": ["testing-kokkos"],
+      "cacheVariables":{
+        "SPINER_TEST_USE_KOKKOS_CUDA": true
+      }
+    }
+  ]
+}

--- a/cmake/content.cmake
+++ b/cmake/content.cmake
@@ -125,7 +125,10 @@ endfunction()
 #   single_value:
 #   - NAMESPACE - the namespace used in the corrisponding `spiner_content_declare` call
 #
-function(spiner_content_populate)
+# NOTE: we use a `macro` so that vars set in any populate steps
+# (add_subdirectory, find_package), will propogate to the caller;
+# this means we need to be careful about polluting the namespace
+macro(spiner_content_populate)
   set(options)
   set(one_value_args
     NAMESPACE
@@ -216,8 +219,15 @@ function(spiner_content_populate)
   endforeach()
 
   # return target list
-  set(${fp_NAMESPACE}_POPULATED_TARGETS ${_expectedTars} PARENT_SCOPE)
-endfunction()
+  set(${fp_NAMESPACE}_POPULATED_TARGETS ${_expectedTars})
+
+  unset(_foundList)
+  unset(_fetchList)
+  unset(_fetchTars)
+  unset(_fetchOpts)
+  unset(_expectedTars)
+
+endmacro()
 
 
 # © 2021. Triad National Security, LLC. All rights reserved.  This

--- a/cmake/content.cmake
+++ b/cmake/content.cmake
@@ -66,8 +66,8 @@ function(spiner_content_declare pkg_name)
   string(TOUPPER ${pkg_name} pkg_CAP)
   string(REPLACE "-" "_" pkg_CAP "${pkg_CAP}")
 
-  message(STATUS
-    "[${pkg_name}] FetchContent_Declare wrapper"
+  message(VERBOSE
+    "[${fp_NAMESPACE}::${pkg_name}] content declared"
   )
   # because the signature is different between versions,
   # we build the cmake call beforehand
@@ -135,9 +135,6 @@ function(spiner_content_populate)
 
   cmake_parse_arguments(fp "${options}" "${one_value_args}" "${multi_value_args}" "${ARGN}")
 
-  message(STATUS 
-    "[${fp_NAMESPACE}] Populating declared content"
-  )
   # fill lists to populate
   # if cmake@3.24+, these are just the lists prepared in spiner_content_declare
   # otherwise, manually check `find_package` and remove content if found
@@ -155,6 +152,7 @@ function(spiner_content_populate)
           "${pkg_name} located with `find_package`"
           "${pkg_name}_DIR: ${${pkg_name}_DIR}"
         )
+        list(APPEND _foundList ${pkg_name})
       else()
         # if no fetching and not found, produce an error
         # conditionally include a custom error msg
@@ -188,15 +186,24 @@ function(spiner_content_populate)
     set(${ext_opt} ON CACHE INTERNAL "")
   endforeach()
 
-  message(VERBOSE "\n"
-      " :: Populating dependency targets ${_fetchTars}\n"
-      " :: Calling `FetchContent_MakeAvailable` with ${_fetchList}\n"
-  )
+  list(LENGTH ${fp_NAMESPACE}_DECLARED_EXTERNAL_CONTENT _ntot)
+
+  message(STATUS 
+    "Content inventory for ${fp_NAMESPACE}")
   message(STATUS
-      "FetchContent_MakeAvailable prepared, "
-      "this may take a few moments if a download is required...\n"
+    " ${_ntot} total declared"
   )
-   # populate
+  
+  foreach(_itr ${${fp_NAMESPACE}_DECLARED_EXTERNAL_CONTENT})
+    message(STATUS
+      "   ${_itr}")
+  endforeach()
+
+  message(STATUS 
+    " making available (this may take a few moments)..."
+  )
+
+  # populate
   FetchContent_MakeAvailable(${_fetchList})
 
   # check that declared targets exist

--- a/cmake/content.cmake
+++ b/cmake/content.cmake
@@ -46,7 +46,7 @@ include(FetchContent)
 #                       if not specified, will default to `<pkg_name>::<pkg_name>`
 #   - ENABLE_OPTS - a list of cache vars used to configure content that is imported using `add_subdirectory()`
 #
-macro(spiner_content_declare pkg_name)
+function(spiner_content_declare pkg_name)
   set(options
     NO_FETCH
   )
@@ -99,23 +99,22 @@ macro(spiner_content_declare pkg_name)
   message(DEBUG " :: FC cmd: ${_fetch_content_cmd}")
   # execute the built `FetchContent_Declare(...)`
   cmake_language(EVAL CODE "${_fetch_content_cmd}")
-  # be safe and destroy the string
-  unset(_fetch_content_cmd)
  
   # return some info
 
   list(APPEND ${fp_NAMESPACE}_DECLARED_EXTERNAL_CONTENT ${pkg_name})
-  set(${fp_NAMESPACE}_DECLARED_EXTERNAL_${pkg_CAP}_COMPONETS ${fp_COMPONENTS})
-  set(${fp_NAMESPACE}_DECLARED_EXTERNAL_${pkg_CAP}_ENABLEOPTS ${fp_ENABLE_OPTS})
-  set(${fp_NAMESPACE}_DECLARED_EXTERNAL_${pkg_CAP}_PRIORS ${fp_PRIORS})
+  set(${fp_NAMESPACE}_DECLARED_EXTERNAL_CONTENT "${${fp_NAMESPACE}_DECLARED_EXTERNAL_CONTENT}" PARENT_SCOPE)
+  set(${fp_NAMESPACE}_DECLARED_EXTERNAL_${pkg_CAP}_COMPONETS ${fp_COMPONENTS} PARENT_SCOPE)
+  set(${fp_NAMESPACE}_DECLARED_EXTERNAL_${pkg_CAP}_ENABLEOPTS ${fp_ENABLE_OPTS} PARENT_SCOPE)
+  set(${fp_NAMESPACE}_DECLARED_EXTERNAL_${pkg_CAP}_PRIORS ${fp_PRIORS} PARENT_SCOPE)
 
   if(fp_EXPECTED_TARGETS)
-      set(${fp_NAMESPACE}_DECLARED_EXTERNAL_${pkg_CAP}_TARGETS ${fp_EXPECTED_TARGETS})
+    set(${fp_NAMESPACE}_DECLARED_EXTERNAL_${pkg_CAP}_TARGETS ${fp_EXPECTED_TARGETS} PARENT_SCOPE)
   else()
-      set(${fp_NAMESPACE}_DECLARED_EXTERNAL_${pkg_CAP}_TARGETS "${pkg_name}::${pkg_name}")
+    set(${fp_NAMESPACE}_DECLARED_EXTERNAL_${pkg_CAP}_TARGETS "${pkg_name}::${pkg_name}" PARENT_SCOPE)
   endif()
 
-endmacro()
+endfunction()
 
 #
 # :: Overview
@@ -126,7 +125,7 @@ endmacro()
 #   single_value:
 #   - NAMESPACE - the namespace used in the corrisponding `spiner_content_declare` call
 #
-macro(spiner_content_populate)
+function(spiner_content_populate)
   set(options)
   set(one_value_args
     NAMESPACE
@@ -210,15 +209,8 @@ macro(spiner_content_populate)
   endforeach()
 
   # return target list
-  set(${fp_NAMESPACE}_POPULATED_TARGETS ${_expectedTars})
-
-  # try to keep scope clean
-  unset(_fetchList)
-  unset(_fetchOpts)
-  unset(_fetchTars)
-  unset(_expectedTars)
-  unset(${fp_NAMESPACE}_DECLARED_EXTERNAL_CONTENT)
-endmacro()
+  set(${fp_NAMESPACE}_POPULATED_TARGETS ${_expectedTars} PARENT_SCOPE)
+endfunction()
 
 
 # © 2021. Triad National Security, LLC. All rights reserved.  This

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,12 +10,6 @@
 # prepare derivative works, distribute copies to the public, perform
 # publicly and display publicly, and to permit others to do so.
 
-spiner_content_declare(Catch2
-  GIT_REPO       https://github.com/catchorg/Catch2.git
-  GIT_TAG        v2.13.7
-  NAMESPACE spinerTest
-)
-
 add_library(spiner_test INTERFACE)
 # instructions for local content
 # https://cmake.org/cmake/help/latest/module/FetchContent.html#variable:FETCHCONTENT_SOURCE_DIR_%3CuppercaseName%3E
@@ -41,16 +35,22 @@ if (SPINER_TEST_USE_KOKKOS)
     EXPECTED_TARGETS Kokkos::kokkos
     ENABLE_OPTS ${_spiner_content_opts}
     NAMESPACE spinerTest
-  )
- 
+  ) 
   target_compile_definitions(spiner_test INTERFACE PORTABILITY_STRATEGY_KOKKOS)
 endif()
+
+spiner_content_declare(Catch2
+  GIT_REPO       https://github.com/catchorg/Catch2.git
+  GIT_TAG        v2.13.7
+  NAMESPACE      spinerTest
+)
 
 # populate test content
 # places targets in `spinerTest_POPULATED_TARGETS`
 spiner_content_populate(
   NAMESPACE spinerTest
 )
+
 target_link_libraries(spiner_test
   INTERFACE
     ${spinerTest_POPULATED_TARGETS}
@@ -63,7 +63,16 @@ target_link_libraries(test.bin
     spiner_test
 )
 
-list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/contrib)
+# workaround for different version/install
+# directory trees for Catch2; 
+# if installed, Catch2Config.cmake _should_ 
+# already set `CMAKE_MODULE_PATH` correctly, and
+# `Catch2_SOURCE_DIR` doesn't exist;
+# however, if not installed then it should exist, 
+# and so we manually append
+if(EXISTS ${Catch2_SOURCE_DIR}/contrib)
+  list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/contrib)
+endif()
 include(Catch)
 catch_discover_tests(test.bin)
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

The `content` CMake code was written as a `macro`. This changes them to `function`. The significance here is scoping: `macro` works like C-preprocessor macros, and just blots the code block into the call site. `function` creates a new, isolated scope. 

The benefit here is to keep variables created in a `function` "inside" the function scope, so they don't pollute the calling namespace. This was causing name-collision issues with updates to `singularity-eos` downstream (https://github.com/lanl/singularity-eos/pull/221)

### 2023-02-14

Some sundry updates that are tagging along (mostly from co-developing updates in `singularity-eos`):
- Edit-down and format the default output of the configure stage, making it more informative and easier to read,
```bash
$> cmake -DCMAKE_BUILD_TYPE=Debug .. -DSPINER_USE_HDF=ON -DSPINER_TEST_USE_KOKKOS=ON
# ...
-- Content inventory for spinerDeps
--  2 total declared
--    ports-of-call
--    HDF5
--  making available (this may take a few moments)...
-- 
Configuring tests
-- Content inventory for spinerTest
--  2 total declared
--    Catch2
--    Kokkos
--  making available (this may take a few moments)...
# ...
```
- Introduced a basic `CMakePresets.json` to store some common configuration setups. These provide some convenience in building towards common setups, and are used as `cmake .. --prefix=testing-kokkos-gpu` (this resolves to `cmake .. -DBUILD_TESTING=ON -DSPINER_TEST_USE_KOKKOS=ON -DSPINER_TEST_USE_KOKKOS_CUDA=ON`). Specific machine architectures can also be given presets. Presets can also "inherit" from previous ones, allowing for easy construction of new ones. Developers can implement a `CMakeUserPresets.json` for that expands on the base presets (the user json is ignored by `.gitignore`). This is useful, for instance, for users with specific environment requirements (@jonahm-LANL @jdolence) to be able to configure the code particularly, without needing the source to be overwrought.  `CMakePresets.json` can also handle build/install and other stages, but for now it seems most beneficial as a convenience for developers. See https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html for more info.
- De-tuned the required CMake version (`3.23 => 3.22`) slightly to allow for easier development/testing on machines that are slower in updating modules (@jhp-lanl)

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- N/A Code is formatted. (You can use the format_spiner make target.)
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

