### PR TITLE
Template on underlying data type

### DIFF
--- a/doc/sphinx/src/getting-started.rst
+++ b/doc/sphinx/src/getting-started.rst
@@ -9,7 +9,7 @@ The following provides a simple example of utilizing a ``DataBox``.
 
   #include <iostream>
   #include <databox.hpp>
-  using namespace Spiner;
+  using DataBox = Spiner::DataBox<double>;
 
   int main() {
     // create a databox

--- a/doc/sphinx/src/interpolation.rst
+++ b/doc/sphinx/src/interpolation.rst
@@ -8,6 +8,19 @@ grids. There is a lower-level object, ``RegularGrid1D`` which contains
 the metadata required for these operations. ``RegularGrid1D`` has a
 few useful userspace functions, which are described here.
 
+Like ``DataBox``, the ``RegularGrid1D`` object is templated on
+underlying data type, the default type being a ``Real`` as provided by
+``ports-of-call``. You may wish to specialize to a specific type with
+a type alias such as:
+
+.. code-block:: cpp
+
+   using RegularGrid1D = Spiner::RegularGrid1D<double>;
+
+.. note::
+   In the function signature below we refer to ``T`` and ``Real`` as
+   the underlying arithmetic data type.
+
 Construction
 ^^^^^^^^^^^^^
 
@@ -16,7 +29,7 @@ grid: the minimum value of the independent variable, the maximum value
 of the independent variable, and the number of points on the
 grid. These are passed into the constructor:
 
-.. cpp:function:: RegularGrid1D::RegularGrid1D(Real min, Real max, size_t N);
+.. cpp:function:: RegularGrid1D::RegularGrid1D(T min, T max, size_t N);
 
 Default constructors and copy constructors are also provided.
 
@@ -25,37 +38,37 @@ Mapping an index to a real number and vice-versa
 
 The function
 
-.. cpp:function:: Real RegularGrid1D::x(const int i) const;
+.. cpp:function:: T RegularGrid1D::x(const int i) const;
 
 returns a "physical" position on the grid given an index ``i``.
 
 The function
 
-.. cpp:function:: int index(const Real x) const;
+.. cpp:function:: int index(const T x) const;
 
 returns the index on the grid of a "physical" value ``x``.
 
 The function
 
-.. cpp:function:: Real min() const;
+.. cpp:function:: T min() const;
 
 returns the minimum value on the independent variable grid.
 
 The function
 
-.. cpp:function:: Real max() const;
+.. cpp:function:: T max() const;
 
 returns the maximum value on the independent variable grid.
 
 The function
 
-.. cpp:function:: Real dx() const;
+.. cpp:function:: T dx() const;
 
 returns the grid spacing for the independent variable.
 
 The function
 
-.. cpp:function:: Real nPoints() const;
+.. cpp:function:: int nPoints() const;
 
 returns the number of points in the independent variable grid.
 

--- a/spiner/databox.hpp
+++ b/spiner/databox.hpp
@@ -45,8 +45,9 @@ enum class IndexType { Interpolated = 0, Named = 1, Indexed = 2 };
 enum class DataStatus { Empty, Unmanaged, AllocatedHost, AllocatedDevice };
 enum class AllocationTarget { Host, Device };
 
-template<typename T=Real,
-	 typename=typename std::enable_if<std::is_arithmetic<T>::value, bool>::type>
+template <typename T = Real,
+          typename =
+              typename std::enable_if<std::is_arithmetic<T>::value, bool>::type>
 class DataBox {
  public:
   using ValueType = T;
@@ -162,7 +163,8 @@ class DataBox {
   PORTABLE_INLINE_FUNCTION DataBox<T> slice(const int indx) const {
     return slice(rank_, indx, 1);
   }
-  PORTABLE_INLINE_FUNCTION DataBox<T> slice(const int ix2, const int ix1) const {
+  PORTABLE_INLINE_FUNCTION DataBox<T> slice(const int ix2,
+                                            const int ix1) const {
     // DataBox a(*this, rank_, ix2, 1);
     // return DataBox(a, a.rank_, ix1, 1);
     return slice(ix2).slice(ix1);
@@ -181,22 +183,22 @@ class DataBox {
   // x1 is fastest index. xN is slowest.
   PORTABLE_FORCEINLINE_FUNCTION T interpToReal(const T x) const noexcept;
   PORTABLE_FORCEINLINE_FUNCTION T interpToReal(const T x2,
-                                                  const T x1) const noexcept;
+                                               const T x1) const noexcept;
   PORTABLE_FORCEINLINE_FUNCTION T interpToReal(const T x3, const T x2,
-                                                  const T x1) const noexcept;
+                                               const T x1) const noexcept;
   PORTABLE_FORCEINLINE_FUNCTION T interpToReal(const T x3, const T x2,
-                                                  const T x1,
-                                                  const int idx) const noexcept;
+                                               const T x1,
+                                               const int idx) const noexcept;
   PORTABLE_FORCEINLINE_FUNCTION T interpToReal(const T x4, const T x3,
-                                                  const T x2,
-                                                  const T x1) const noexcept;
+                                               const T x2,
+                                               const T x1) const noexcept;
   // Interpolates the whole databox to a real number,
   // with one intermediate, non-interpolatable index,
   // which is simply indexed into
   // JMM: Trust me---this is a common pattern
   PORTABLE_FORCEINLINE_FUNCTION T interpToReal(const T x4, const T x3,
-                                                  const T x2, const int idx,
-                                                  const T x1) const noexcept;
+                                               const T x2, const int idx,
+                                               const T x1) const noexcept;
   // Interpolates SLOWEST indices of databox to a new
   // DataBox, interpolated at that slowest index.
   // WARNING: requires memory to be pre-allocated.
@@ -312,7 +314,8 @@ class DataBox {
       DeviceView_t devView(device_data, dataView_.GetSize());
       HostView_t hostView(data_, dataView_.GetSize());
       deep_copy(devView, hostView);
-      DataBox<T> a{devView.data(), dim(6), dim(5), dim(4), dim(3), dim(2), dim(1)};
+      DataBox<T> a{devView.data(), dim(6), dim(5), dim(4),
+                   dim(3),         dim(2), dim(1)};
       a.copyShape(*this);
       a.status_ = DataStatus::AllocatedDevice;
       return a;
@@ -372,21 +375,21 @@ class DataBox {
 };
 
 // Read an array, shallow
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 inline void DataBox<T, Concept>::setArray(PortableMDArray<T> &A) {
   dataView_ = A;
   rank_ = A.GetRank();
   setAllIndexed_();
 }
 
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 PORTABLE_INLINE_FUNCTION T
 DataBox<T, Concept>::interpToReal(const T x) const noexcept {
   assert(canInterpToReal_(1));
   return grids_[0](x, dataView_);
 }
 
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 PORTABLE_FORCEINLINE_FUNCTION T
 DataBox<T, Concept>::interpToReal(const T x2, const T x1) const noexcept {
   assert(canInterpToReal_(2));
@@ -402,7 +405,7 @@ DataBox<T, Concept>::interpToReal(const T x2, const T x1) const noexcept {
                    w1[1] * dataView_(ix2 + 1, ix1 + 1)));
 }
 
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 PORTABLE_FORCEINLINE_FUNCTION T DataBox<T, Concept>::interpToReal(
     const T x3, const T x2, const T x1) const noexcept {
   assert(canInterpToReal_(3));
@@ -425,7 +428,7 @@ PORTABLE_FORCEINLINE_FUNCTION T DataBox<T, Concept>::interpToReal(
                       w[0][1] * dataView_(ix[2] + 1, ix[1] + 1, ix[0] + 1))));
 }
 
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 PORTABLE_FORCEINLINE_FUNCTION T DataBox<T, Concept>::interpToReal(
     const T x3, const T x2, const T x1, const int idx) const noexcept {
   assert(rank_ == 4);
@@ -456,7 +459,7 @@ PORTABLE_FORCEINLINE_FUNCTION T DataBox<T, Concept>::interpToReal(
 
 // DH: this is a large function to force an inline, perhaps just make it a
 // suggestion to the compiler?
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 PORTABLE_FORCEINLINE_FUNCTION T DataBox<T, Concept>::interpToReal(
     const T x4, const T x3, const T x2, const T x1) const noexcept {
   assert(canInterpToReal_(4));
@@ -507,10 +510,10 @@ PORTABLE_FORCEINLINE_FUNCTION T DataBox<T, Concept>::interpToReal(
   );
 }
 
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 PORTABLE_FORCEINLINE_FUNCTION T
 DataBox<T, Concept>::interpToReal(const T x4, const T x3, const T x2,
-                      const int idx, const T x1) const noexcept {
+                                  const int idx, const T x1) const noexcept {
   assert(rank_ == 5);
   assert(indices_[0] == IndexType::Interpolated);
   assert(grids_[0].isWellFormed());
@@ -570,9 +573,9 @@ DataBox<T, Concept>::interpToReal(const T x4, const T x3, const T x2,
   );
 }
 
-template<typename T, typename Concept>
-PORTABLE_INLINE_FUNCTION void DataBox<T, Concept>::interpFromDB(const DataBox<T> &db,
-						       const T x) {
+template <typename T, typename Concept>
+PORTABLE_INLINE_FUNCTION void
+DataBox<T, Concept>::interpFromDB(const DataBox<T> &db, const T x) {
   assert(db.indices_[db.rank_ - 1] == IndexType::Interpolated);
   assert(db.grids_[db.rank_ - 1].isWellFormed());
   assert(size() == (db.size() / db.dim(db.rank_)));
@@ -590,9 +593,10 @@ PORTABLE_INLINE_FUNCTION void DataBox<T, Concept>::interpFromDB(const DataBox<T>
   }
 }
 
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 PORTABLE_INLINE_FUNCTION void
-DataBox<T, Concept>::interpFromDB(const DataBox<T> &db, const T x2, const T x1) {
+DataBox<T, Concept>::interpFromDB(const DataBox<T> &db, const T x2,
+                                  const T x1) {
   assert(db.rank_ >= 2);
   assert(db.indices_[db.rank_ - 1] == IndexType::Interpolated);
   assert(db.grids_[db.rank_ - 1].isWellFormed());
@@ -606,8 +610,9 @@ DataBox<T, Concept>::interpFromDB(const DataBox<T> &db, const T x2, const T x1) 
 
   db.grids_[db.rank_ - 2].weights(x1, ix1, w1);
   db.grids_[db.rank_ - 1].weights(x2, ix2, w2);
-  DataBox<T> corners[2][2]{{db.slice(ix2, ix1), db.slice(ix2 + 1, ix1)},
-                        {db.slice(ix2, ix1 + 1), db.slice(ix2 + 1, ix1 + 1)}};
+  DataBox<T> corners[2][2]{
+      {db.slice(ix2, ix1), db.slice(ix2 + 1, ix1)},
+      {db.slice(ix2, ix1 + 1), db.slice(ix2 + 1, ix1 + 1)}};
   //    copyShape(db,2);
   //
   //    db.grids_[db.rank_-2].weights(x1, ix1, w1);
@@ -634,9 +639,9 @@ DataBox<T, Concept>::interpFromDB(const DataBox<T> &db, const T x2, const T x1) 
 // Reshapes from other databox, but does not allocate memory.
 // Does no checks that memory is available.
 // Optionally copies shape of source with ndims fewer slowest-moving dimensions
-template<typename T, typename Concept>
-PORTABLE_INLINE_FUNCTION void DataBox<T, Concept>::copyShape(const DataBox<T> &db,
-                                                 const int ndims) {
+template <typename T, typename Concept>
+PORTABLE_INLINE_FUNCTION void
+DataBox<T, Concept>::copyShape(const DataBox<T> &db, const int ndims) {
   rank_ = db.rank_ - ndims;
   int dims[MAXRANK];
   for (int i = 0; i < MAXRANK; i++)
@@ -653,7 +658,7 @@ PORTABLE_INLINE_FUNCTION void DataBox<T, Concept>::copyShape(const DataBox<T> &d
 }
 // reallocates and then copies shape from other databox
 // everything but the actual copy in a deep copy
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 inline void DataBox<T, Concept>::copyMetadata(const DataBox<T> &src) {
   AllocationTarget t =
       (src.status_ == DataStatus::AllocatedDevice ? AllocationTarget::Device
@@ -668,7 +673,7 @@ inline void DataBox<T, Concept>::copyMetadata(const DataBox<T> &src) {
 }
 
 #ifdef SPINER_USE_HDF
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 inline herr_t DataBox<T, Concept>::saveHDF(const std::string &filename) const {
   herr_t status;
   hid_t file;
@@ -679,15 +684,17 @@ inline herr_t DataBox<T, Concept>::saveHDF(const std::string &filename) const {
   return status;
 }
 
-template<typename T, typename Concept>
-inline herr_t DataBox<T, Concept>::saveHDF(hid_t loc, const std::string &groupname) const {
+template <typename T, typename Concept>
+inline herr_t DataBox<T, Concept>::saveHDF(hid_t loc,
+                                           const std::string &groupname) const {
   hid_t group, grids;
   herr_t status = 0;
   static_assert(std::is_same<T, double>::value || std::is_same<T, float>::value,
-		"Spiner HDF5 only defined for these data types: float, double");
-  // Runtime because HDF5 is doing something evil under the hood with these macros
-  auto H5T_T = std::is_same<T, double>::value ? H5T_NATIVE_DOUBLE : H5T_NATIVE_FLOAT;
-
+                "Spiner HDF5 only defined for these data types: float, double");
+  // Runtime because HDF5 is doing something evil under the hood with these
+  // macros
+  auto H5T_T =
+      std::is_same<T, double>::value ? H5T_NATIVE_DOUBLE : H5T_NATIVE_FLOAT;
 
   std::vector<int> dims_int(rank_);
   for (int i = 0; i < rank_; i++)
@@ -738,7 +745,7 @@ inline herr_t DataBox<T, Concept>::saveHDF(hid_t loc, const std::string &groupna
   return status;
 }
 
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 inline herr_t DataBox<T, Concept>::loadHDF(const std::string &filename) {
   herr_t status;
   hid_t file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
@@ -746,16 +753,19 @@ inline herr_t DataBox<T, Concept>::loadHDF(const std::string &filename) {
   return status;
 }
 
-template<typename T, typename Concept>
-inline herr_t DataBox<T, Concept>::loadHDF(hid_t loc, const std::string &groupname) {
+template <typename T, typename Concept>
+inline herr_t DataBox<T, Concept>::loadHDF(hid_t loc,
+                                           const std::string &groupname) {
   hid_t group, grids;
   herr_t status = 0;
   std::vector<int> index_types;
   std::vector<int> dims(6, 1);
   static_assert(std::is_same<T, double>::value || std::is_same<T, float>::value,
-		"Spiner HDF5 only defined for these data types: float, double");
-  // Runtime because HDF5 is doing something evil under the hood with these macros
-  auto H5T_T = std::is_same<T, double>::value ? H5T_NATIVE_DOUBLE : H5T_NATIVE_FLOAT;
+                "Spiner HDF5 only defined for these data types: float, double");
+  // Runtime because HDF5 is doing something evil under the hood with these
+  // macros
+  auto H5T_T =
+      std::is_same<T, double>::value ? H5T_NATIVE_DOUBLE : H5T_NATIVE_FLOAT;
 
   // Open group
   group = H5Gopen(loc, groupname.c_str(), H5P_DEFAULT);
@@ -775,8 +785,7 @@ inline herr_t DataBox<T, Concept>::loadHDF(hid_t loc, const std::string &groupna
             dims[0]);
   dataView_.NewPortableMDArray(data_, dims[5], dims[4], dims[3], dims[2],
                                dims[1], dims[0]);
-  status +=
-      H5LTread_dataset(group, SP5::DB::DSETNAME, H5T_T, dataView_.data());
+  status += H5LTread_dataset(group, SP5::DB::DSETNAME, H5T_T, dataView_.data());
 
   // Get index types
   index_types.resize(rank_);
@@ -801,8 +810,9 @@ inline herr_t DataBox<T, Concept>::loadHDF(hid_t loc, const std::string &groupna
 #endif // SPINER_USE_HDF
 
 // Performs shallow copy by default
-template<typename T, typename Concept>
-PORTABLE_INLINE_FUNCTION DataBox<T> &DataBox<T, Concept>::operator=(const DataBox<T> &src) {
+template <typename T, typename Concept>
+PORTABLE_INLINE_FUNCTION DataBox<T> &
+DataBox<T, Concept>::operator=(const DataBox<T> &src) {
   if (this != &src) {
     rank_ = src.rank_;
     status_ = src.status_;
@@ -817,14 +827,14 @@ PORTABLE_INLINE_FUNCTION DataBox<T> &DataBox<T, Concept>::operator=(const DataBo
 }
 
 // Performs a deep copy
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 inline void DataBox<T, Concept>::copy(const DataBox<T> &src) {
   copyMetadata(src);
   for (int i = 0; i < src.size(); i++)
     dataView_(i) = src(i);
 }
 
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 inline bool DataBox<T, Concept>::operator==(const DataBox<T> &other) const {
   if (rank_ != other.rank_) return false;
   for (int i = 0; i < rank_; i++) {
@@ -838,7 +848,7 @@ inline bool DataBox<T, Concept>::operator==(const DataBox<T> &other) const {
 }
 
 // TODO: should this be std::reduce?
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 PORTABLE_INLINE_FUNCTION T DataBox<T, Concept>::min() const {
   T min = std::numeric_limits<T>::infinity();
   for (int i = 0; i < size(); i++) {
@@ -847,7 +857,7 @@ PORTABLE_INLINE_FUNCTION T DataBox<T, Concept>::min() const {
   return min;
 }
 
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 PORTABLE_INLINE_FUNCTION T DataBox<T, Concept>::max() const {
   T max = -std::numeric_limits<T>::infinity();
   for (int i = 0; i < size(); i++) {
@@ -856,9 +866,9 @@ PORTABLE_INLINE_FUNCTION T DataBox<T, Concept>::max() const {
   return max;
 }
 
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 PORTABLE_INLINE_FUNCTION void DataBox<T, Concept>::range(int i, T &min, T &max,
-                                             T &dx, int &N) const {
+                                                         T &dx, int &N) const {
   assert(0 <= i && i < rank_);
   assert(indices_[i] == IndexType::Interpolated);
   min = grids_[i].min();
@@ -867,21 +877,22 @@ PORTABLE_INLINE_FUNCTION void DataBox<T, Concept>::range(int i, T &min, T &max,
   N = grids_[i].nPoints();
 }
 
-template<typename T, typename Concept>
-PORTABLE_INLINE_FUNCTION RegularGrid1D<T> DataBox<T, Concept>::range(int i) const {
+template <typename T, typename Concept>
+PORTABLE_INLINE_FUNCTION RegularGrid1D<T>
+DataBox<T, Concept>::range(int i) const {
   assert(0 <= i && i < rank_);
   assert(indices_[i] == IndexType::Interpolated);
   return grids_[i];
 }
 
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 PORTABLE_INLINE_FUNCTION void DataBox<T, Concept>::setAllIndexed_() {
   for (int i = 0; i < rank_; i++) {
     indices_[i] = IndexType::Indexed;
   }
 }
 
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 PORTABLE_INLINE_FUNCTION bool
 DataBox<T, Concept>::canInterpToReal_(const int interpOrder) const {
   if (rank_ != interpOrder) return false;
@@ -892,15 +903,17 @@ DataBox<T, Concept>::canInterpToReal_(const int interpOrder) const {
   return true;
 }
 
-template<typename T, typename Concept>
+template <typename T, typename Concept>
 inline DataBox<T, Concept> getOnDeviceDataBox(const DataBox<T> &a_host) {
   return a_host.getOnDevice();
 }
-template<typename T, typename Concept>
-inline void free(DataBox<T, Concept> &db) { db.finalize(); }
+template <typename T, typename Concept>
+inline void free(DataBox<T, Concept> &db) {
+  db.finalize();
+}
 
 struct DBDeleter {
-template <typename T>
+  template <typename T>
   void operator()(T *ptr) {
     ptr->finalize();
     delete ptr;

--- a/spiner/interpolation.hpp
+++ b/spiner/interpolation.hpp
@@ -34,7 +34,7 @@
 namespace Spiner {
 
 // a poor-man's std::double
-template<typename T=Real>
+template <typename T = Real>
 struct weights_t {
   T first, second;
   PORTABLE_INLINE_FUNCTION Real &operator[](const int i) {
@@ -43,7 +43,9 @@ struct weights_t {
   }
 };
 
-template<typename T=Real, typename std::enable_if<std::is_arithmetic<T>::value, bool>::type = true>
+template <typename T = Real,
+          typename std::enable_if<std::is_arithmetic<T>::value, bool>::type =
+              true>
 class RegularGrid1D {
  public:
   using ValueType = T;
@@ -85,7 +87,8 @@ class RegularGrid1D {
   }
 
   // Returns closest index and weights for interpolation
-  PORTABLE_INLINE_FUNCTION void weights(const T &x, int &ix, weights_t<T> &w) const {
+  PORTABLE_INLINE_FUNCTION void weights(const T &x, int &ix,
+                                        weights_t<T> &w) const {
     ix = index(x);
     const auto floor = static_cast<T>(ix) * dx_ + min_;
     w[1] = idx_ * (x - floor);
@@ -93,8 +96,8 @@ class RegularGrid1D {
   }
 
   // 1D interpolation
-  PORTABLE_INLINE_FUNCTION T
-  operator()(const T &x, const PortableMDArray<T> &A) const {
+  PORTABLE_INLINE_FUNCTION T operator()(const T &x,
+                                        const PortableMDArray<T> &A) const {
     int ix;
     weights_t<T> w;
     weights(x, ix, w);

--- a/spiner/interpolation.hpp
+++ b/spiner/interpolation.hpp
@@ -34,25 +34,29 @@ namespace Spiner {
 // TODO: be more careful about what this number should be
 // sqrt machine epsilon or something
 constexpr Real EPS = 10.0 * std::numeric_limits<Real>::epsilon();
-constexpr Real rNaN = std::numeric_limits<Real>::signaling_NaN();
-constexpr int iNaN = std::numeric_limits<int>::signaling_NaN();
 
 // a poor-man's std::double
+template<typename T=Real>
 struct weights_t {
-  Real first, second;
+  T first, second;
   PORTABLE_INLINE_FUNCTION Real &operator[](const int i) {
     assert(0 <= i && i <= 1);
     return i == 0 ? first : second;
   }
 };
 
+template<typename T=Real>
 class RegularGrid1D {
  public:
+  using ValueType = T;
+  static constexpr T rNaN = std::numeric_limits<T>::signaling_NaN();
+  static constexpr int iNaN = std::numeric_limits<int>::signaling_NaN();
+
   // Constructors
   PORTABLE_INLINE_FUNCTION RegularGrid1D()
       : min_(rNaN), max_(rNaN), dx_(rNaN), idx_(rNaN), N_(iNaN) {}
-  PORTABLE_INLINE_FUNCTION RegularGrid1D(Real min, Real max, size_t N)
-      : min_(min), max_(max), dx_((max - min) / ((Real)(N - 1))), idx_(1 / dx_),
+  PORTABLE_INLINE_FUNCTION RegularGrid1D(T min, T max, size_t N)
+      : min_(min), max_(max), dx_((max - min) / ((T)(N - 1))), idx_(1 / dx_),
         N_(N) {}
 
   // Assignment operator
@@ -77,24 +81,24 @@ class RegularGrid1D {
   }
 
   // Gets real value at index
-  PORTABLE_INLINE_FUNCTION Real x(const int i) const { return i * dx_ + min_; }
-  PORTABLE_INLINE_FUNCTION int index(const Real x) const {
+  PORTABLE_INLINE_FUNCTION T x(const int i) const { return i * dx_ + min_; }
+  PORTABLE_INLINE_FUNCTION int index(const T x) const {
     return bound(idx_ * (x - min_));
   }
 
   // Returns closest index and weights for interpolation
-  PORTABLE_INLINE_FUNCTION void weights(Real x, int &ix, weights_t &w) const {
+  PORTABLE_INLINE_FUNCTION void weights(T x, int &ix, weights_t<T> &w) const {
     ix = index(x);
-    const Real floor = ix * dx_ + min_;
+    const T floor = ix * dx_ + min_;
     w[1] = idx_ * (x - floor);
     w[0] = (1. - w[1]);
   }
 
   // 1D interpolation
-  PORTABLE_INLINE_FUNCTION Real
-  operator()(const Real x, const PortableMDArray<Real> &A) const {
+  PORTABLE_INLINE_FUNCTION T
+  operator()(const T x, const PortableMDArray<T> &A) const {
     int ix;
-    weights_t w;
+    weights_t<T> w;
     weights(x, ix, w);
     return w[0] * A(ix) + w[1] * A(ix + 1);
   }
@@ -107,20 +111,20 @@ class RegularGrid1D {
   PORTABLE_INLINE_FUNCTION bool operator!=(const RegularGrid1D &other) const {
     return !(*this == other);
   }
-  PORTABLE_INLINE_FUNCTION Real min() const { return min_; }
-  PORTABLE_INLINE_FUNCTION Real max() const { return max_; }
-  PORTABLE_INLINE_FUNCTION Real dx() const { return dx_; }
+  PORTABLE_INLINE_FUNCTION T min() const { return min_; }
+  PORTABLE_INLINE_FUNCTION T max() const { return max_; }
+  PORTABLE_INLINE_FUNCTION T dx() const { return dx_; }
   PORTABLE_INLINE_FUNCTION size_t nPoints() const { return N_; }
   PORTABLE_INLINE_FUNCTION bool isnan() const {
     return (std::isnan(min_) || std::isnan(max_) || std::isnan(dx_) ||
-            std::isnan(idx_) || std::isnan((Real)N_));
+            std::isnan(idx_) || std::isnan((T)N_));
   }
   PORTABLE_INLINE_FUNCTION bool isWellFormed() const { return !isnan(); }
 
 #ifdef SPINER_USE_HDF
   inline herr_t saveHDF(hid_t loc, const std::string &name) const {
     herr_t status;
-    Real range[] = {min_, max_, dx_};
+    T range[] = {min_, max_, dx_};
     hsize_t range_dims[] = {3};
     int n = static_cast<int>(N_);
     status = H5LTmake_dataset(loc, name.c_str(), SP5::RG1D::RANGE_RANK,
@@ -133,7 +137,7 @@ class RegularGrid1D {
 
   inline herr_t loadHDF(hid_t loc, const std::string &name) {
     herr_t status;
-    Real range[3];
+    T range[3];
     int n;
     status = H5LTread_dataset(loc, name.c_str(), H5T_REAL, range);
     min_ = range[0];
@@ -147,8 +151,8 @@ class RegularGrid1D {
 #endif
 
  private:
-  Real min_, max_;
-  Real dx_, idx_;
+  T min_, max_;
+  T dx_, idx_;
   size_t N_;
 };
 

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -27,8 +27,9 @@
 #include <spiner/interpolation.hpp>
 #include <spiner/spiner_types.hpp>
 
-using Spiner::DataBox;
+using DataBox = Spiner::DataBox<Real>;
 using RegularGrid1D = Spiner::RegularGrid1D<Real>;
+using Spiner::DBDeleter;
 
 using duration = std::chrono::nanoseconds;
 
@@ -78,7 +79,7 @@ int main(int argc, char *argv[]) {
     }
 
     std::cout << "# ncoarse = " << ncoarse << std::endl;
-    std::unique_ptr<DataBox, Spiner::DBDeleter> pdb(new DataBox(
+    std::unique_ptr<DataBox, DBDeleter> pdb(new DataBox(
         Spiner::AllocationTarget::Device, ncoarse, ncoarse, ncoarse));
     for (int d = 0; d < pdb->rank(); d++) {
       pdb->setRange(d, xmin, xmax, ncoarse);

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -28,7 +28,7 @@
 #include <spiner/spiner_types.hpp>
 
 using Spiner::DataBox;
-using Spiner::RegularGrid1D;
+using RegularGrid1D = Spiner::RegularGrid1D<Real>;
 
 using duration = std::chrono::nanoseconds;
 

--- a/test/convergence.cpp
+++ b/test/convergence.cpp
@@ -22,7 +22,7 @@
 #include <spiner/spiner_types.hpp>
 
 using Spiner::DataBox;
-using Spiner::RegularGrid1D;
+using RegularGrid1D = Spiner::RegularGrid1D<Real>;
 
 const std::string outname = "convergence.dat";
 

--- a/test/convergence.cpp
+++ b/test/convergence.cpp
@@ -21,7 +21,7 @@
 #include <spiner/interpolation.hpp>
 #include <spiner/spiner_types.hpp>
 
-using Spiner::DataBox;
+using DataBox = Spiner::DataBox<Real>;
 using RegularGrid1D = Spiner::RegularGrid1D<Real>;
 
 const std::string outname = "convergence.dat";

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -28,7 +28,7 @@
 
 using Spiner::DataBox;
 using Spiner::IndexType;
-using Spiner::RegularGrid1D;
+using RegularGrid1D = Spiner::RegularGrid1D<Real>;
 const Real EPSTEST = std::sqrt(Spiner::EPS);
 
 PORTABLE_INLINE_FUNCTION Real linearFunction(Real z, Real y, Real x) {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -30,7 +30,7 @@ using DataBox = Spiner::DataBox<Real>;
 using Spiner::IndexType;
 using RegularGrid1D = Spiner::RegularGrid1D<Real>;
 using Spiner::DBDeleter;
-const Real EPSTEST = std::sqrt(Spiner::EPS);
+const Real EPSTEST = std::sqrt(DataBox::EPS);
 
 PORTABLE_INLINE_FUNCTION Real linearFunction(Real z, Real y, Real x) {
   return x + y + z;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -26,9 +26,10 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch2/catch.hpp"
 
-using Spiner::DataBox;
+using DataBox = Spiner::DataBox<Real>;
 using Spiner::IndexType;
 using RegularGrid1D = Spiner::RegularGrid1D<Real>;
+using Spiner::DBDeleter;
 const Real EPSTEST = std::sqrt(Spiner::EPS);
 
 PORTABLE_INLINE_FUNCTION Real linearFunction(Real z, Real y, Real x) {
@@ -563,7 +564,7 @@ SCENARIO("Using unique pointers to garbage collect DataBox",
          "[DataBox][GarbageCollection]") {
   constexpr int N = 1000;
   GIVEN("A databox allocated on device with a unique pointer") {
-    std::unique_ptr<DataBox, Spiner::DBDeleter> pdb(
+    std::unique_ptr<DataBox, DBDeleter> pdb(
         new DataBox(Spiner::AllocationTarget::Device, N));
     THEN("We can access it") {
       auto db = *pdb; // shallow copy


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

The use case of mixed-precision computing has been suggested. This PR attempts to support that need by templating `Spiner` functionality on underlying data type. This means the following are all valid:

```C++
Spiner::DataBox<float> db(3, 2, 1);
Spiner::DataBox<double> db(5, 4, 3);
Spiner::DataBox<long double> db(55);
```

Any arithmetic type is supported, although I've only tested carefully with floating-point types. Also HDF5 is only supported for `float` and `double` at this time.

I've pinged a few people using spiner downstream. @jdolence @chadmeyer @dholladay00 @jhp-lanl and @brryan do you see this breaking anything you're doing with spiner? Is there any design consideration I'm missing here?

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code is formatted. (You can use the format_spiner make target.)
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

