### PR TITLE
CI: upgrade to CUDA 11.6 on power9

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,7 +52,7 @@ before_script:
     SCHEDULER_PARAMETERS: "--nodes=1 --partition=skylake-gold,skylake-platinum"
 
 .power9: &power9
-    SCHEDULER_PARAMETERS: "--nodes=1 --partition=power9"
+    SCHEDULER_PARAMETERS: "--nodes=1 --partition=power9-rhel7"
 
 #################
 # General Setup #

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@ stages:
 variables:
   GIT_SUBMODULE_STRATEGY: recursive
   SPINER_GCC_VERSION: "9.3.0"
+  SPINER_CUDA_VERSION: "11.6.0"
   SPINER_SPACK_SPEC: "spiner@main+python%gcc@${SPINER_GCC_VERSION}"
   COLOR_CYAN: '\033[1;36m'
   COLOR_PLAIN: '\033[0m'
@@ -79,7 +80,7 @@ before_script:
     - .job
   script:
     - module load gcc/${SPINER_GCC_VERSION}
-    - module load cuda/11.4.2
+    - module load cuda/${SPINER_CUDA_VERSION}
     - |
       if [[ ${CI_JOB_NAME} =~ "power9" ]];
       then


### PR DESCRIPTION
## PR Summary

The CI pipeline was still loading the CUDA 11.4 module.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code is formatted. (You can use the format_spiner make target.)
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

