### PR TITLE
Initial commit to remove kokkos specific code for copying views, base…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,8 @@ spiner_content_declare(ports-of-call
   NAMESPACE spinerDeps
   GIT_REPO    https://github.com/lanl/ports-of-call
   # NOTE: main as of Nov. 28 2022 
-  GIT_TAG     3fffe08408b1ee754d0567a3de63cb47ce97d9f7
+  #GIT_TAG     3fffe08408b1ee754d0567a3de63cb47ce97d9f7
+  GIT_TAG v1.5.1
 )
 
 if(SPINER_USE_HDF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,7 @@ include(content)
 spiner_content_declare(ports-of-call
   NAMESPACE spinerDeps
   GIT_REPO    https://github.com/lanl/ports-of-call
-  # NOTE: main as of Nov. 28 2022 
-  #GIT_TAG     3fffe08408b1ee754d0567a3de63cb47ce97d9f7
+  # most recent relase as of April 05, 2023
   GIT_TAG v1.5.1
 )
 

--- a/spack-repo/packages/ports-of-call/package.py
+++ b/spack-repo/packages/ports-of-call/package.py
@@ -16,6 +16,7 @@ class PortsOfCall(CMakePackage):
     maintainers = ["rbberger"]
 
     version("main", branch="main")
+    version("1.5.1", sha256="b1f0232cd6d2aac65385d77cc061ec5035283ea50d0f167e7003eae034effb78")
     version("1.4.1", sha256="82d2c75fcca8bd613273fd4126749df68ccc22fbe4134ba673b4275f9972b78d")
     version("1.4.0", sha256="e08ae556b7c30d14d77147d248d118cf5343a2e8c0847943385c602394bda0fa")
     version("1.3.0", sha256="54b4a62539c23b1a345dd87c1eac65f4f69db4e50336cd81a15a627ce80ce7d9")

--- a/spack-repo/packages/spiner/package.py
+++ b/spack-repo/packages/spiner/package.py
@@ -53,7 +53,7 @@ class Spiner(CMakePackage, CudaPackage):
     depends_on("cmake@3.23:", when="@1.6.0:")
     depends_on("catch2@2.13.4:2.13.9")
     depends_on("ports-of-call@1.2.0:", when="@:1.5.1")
-    depends_on("ports-of-call@1.3.0:", when="@1.6.0:")
+    depends_on("ports-of-call@1.5.1:", when="@1.6.0:")
 
     # Currently the raw cuda backend of ports-of-call is not supported.
     depends_on("ports-of-call portability_strategy=Kokkos", when="@:1.5.1 +kokkos")
@@ -63,7 +63,7 @@ class Spiner(CMakePackage, CudaPackage):
     for _flag in ("~cuda", "+cuda", "~openmp", "+openmp"):
         depends_on("kokkos@3.3.00: " + _flag, when="+kokkos" + _flag)
     depends_on(
-        "kokkos@3.3.00: ~shared+wrapper+cuda_lambda+cuda_constexpr+cuda_relocatable_device_code",
+        "kokkos@3.3.00: ~shared+wrapper+cuda_lambda+cuda_constexpr",
         when="+cuda+kokkos",
     )
 

--- a/spiner/databox.hpp
+++ b/spiner/databox.hpp
@@ -296,21 +296,17 @@ class DataBox {
 
   // TODO(JMM): Add more code for more portability strategies
   DataBox<T> getOnDevice() const { // getOnDevice is always a deep copy
-#ifdef __CUDACC__
-    constexpr const bool execution_is_host = false;
-#else
-    constexpr const bool execution_is_host = true;
-#endif // __CUDACC__
     // create device memory (host memory if no device)
     T *device_data = (T *)PORTABLE_MALLOC(sizeBytes());
     // copy to device
     portableCopyToDevice(device_data, data_, sizeBytes());
     // create new databox of size size
-    DataBox<T> a{device_data, dim(6), dim(5), dim(4),
-                 dim(3),         dim(2), dim(1)};
+    DataBox<T> a{device_data, dim(6), dim(5), dim(4), dim(3), dim(2), dim(1)};
     a.copyShape(*this);
     // this may need logic for if host? JMM thoughts?
-    if (!execution_is_host) {
+    if (PortsOfCall::EXECUTION_IS_HOST) {
+      a.status_ = DataStatus::AllocatedHost;
+    } else {
       a.status_ = DataStatus::AllocatedDevice;
     }
     return a;

--- a/spiner/databox.hpp
+++ b/spiner/databox.hpp
@@ -294,7 +294,6 @@ class DataBox {
     return indices_[i];
   }
 
-  // TODO(JMM): Add more code for more portability strategies
   DataBox<T> getOnDevice() const { // getOnDevice is always a deep copy
     // create device memory (host memory if no device)
     T *device_data = (T *)PORTABLE_MALLOC(sizeBytes());
@@ -303,7 +302,7 @@ class DataBox {
     // create new databox of size size
     DataBox<T> a{device_data, dim(6), dim(5), dim(4), dim(3), dim(2), dim(1)};
     a.copyShape(*this);
-    // this may need logic for if host? JMM thoughts?
+    // set correct allocation status of the new databox
     if (PortsOfCall::EXECUTION_IS_HOST) {
       a.status_ = DataStatus::AllocatedHost;
     } else {


### PR DESCRIPTION
…d on new ports-of-call capabilities.

<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

This PR removes kokkos specific code from spiner for the `getondevice` function. 
Addresses #54 

@mauneyc-LANL @Yurlungur please take a look. I think poc needs more functionality to expose information about memory/execution spaces so that I don't need the hacky preprocessor stuff. 

I should also note that this won't work until the latest changes from ports-of-call are pulled in. 

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code is formatted. (You can use the format_spiner make target.)
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] If preparing for a new release, update the version in cmake.

