### PR TITLE
Add GitHub action to update spackages 🤖 

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -1,0 +1,46 @@
+name: Check Spack dependencies for updates
+
+on:
+  # for manual jobs
+  workflow_dispatch:
+  # triggers at around 15:00 UTC (with some delay)
+  schedule:
+   - cron: '0 15 * * *'
+
+jobs:
+    deps:
+      name:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout this repo
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+        - name: create build
+          run: mkdir build
+        - name: Checkout ports-of-call
+          uses: actions/checkout@v2
+          with:
+            repository: lanl/ports-of-call
+            path: build/ports-of-call
+            fetch-depth: 0
+        - name: copy over spack-repo/packages
+          run: cp -R build/ports-of-call/spack-repo/packages/* spack-repo/packages/
+        - name: is there a difference?
+          run: git diff --exit-code --compact-summary
+          id: no_change
+        - name: create branch
+          if: ${{ steps.no_change.conclusion == 'failure' }}
+          run: |
+            git config user.name 'github-actions[bot]'
+            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            git branch -D github-bot/update_spackages || true
+            git checkout -b github-bot/update_spackages
+            git add spack-repo
+            git commit -m "spack updates"
+            git push -f --set-upstream origin github-bot/update_spackages
+        - name: create pull request
+          if: ${{ steps.no_change.conclusion == 'failure' }}
+          run: gh pr create -B main -H github-bot/update_spackages --title 'Update spackages' --body 'Created by Github action'
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -13,13 +13,13 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout this repo
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
         - name: create build
           run: mkdir build
         - name: Checkout ports-of-call
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             repository: lanl/ports-of-call
             path: build/ports-of-call

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
 
       steps:      
         - name: Checkout code
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             fetch-depth: 0
         - name: Set system to non-interactive mode

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -13,7 +13,7 @@ jobs:
 
       steps:      
         - name: Checkout code
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
         - name: Set system to non-interactive mode
           run: export DEBIAN_FRONTEND=noninteractive
         - name: install dependencies


### PR DESCRIPTION
## PR Summary

This adds a manual and scheduled action to check for changes in ports-of-call spackages and migrate them over to Spiner. If a change is detected, it will create a PR authored by a bot.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code is formatted. (You can use the format_spiner make target.)
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

