### PR TITLE
fix getondevice

### DIFF
--- a/spiner/databox.hpp
+++ b/spiner/databox.hpp
@@ -307,11 +307,8 @@ class DataBox {
                           dim(3),      dim(2), dim(1)};
     a.copyShape(*this);
     // set correct allocation status of the new databox
-    if (PortsOfCall::EXECUTION_IS_HOST) {
-      a.status_ = DataStatus::AllocatedHost;
-    } else {
-      a.status_ = DataStatus::AllocatedDevice;
-    }
+    // note this is ALWAYS device, even if host==device.
+    a.status_ = DataStatus::AllocatedDevice;
     return a;
   }
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Even with only host context, it turns out `Kokkos::Malloc` and `Kokkos::Free` are not just the standard `malloc` and `free`. What this means is that if you build Spiner with `Kokkos` backend but no device, it's still dangerous to mix `PORTABLE_MALLOC` with `free`. This was causing a segfault in this particular edge case. Now fixed.

In the long term, to catch such things, we should probably add a Kokkos serial build to the Spiner CI. I didn't bother for now though.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code is formatted. (You can use the format_spiner make target.)
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

