### PR TITLE
Reduce minimum CMake required

### DIFF
--- a/spack-repo/packages/spiner/package.py
+++ b/spack-repo/packages/spiner/package.py
@@ -51,7 +51,7 @@ class Spiner(CMakePackage, CudaPackage):
     variant("python", default=False, description="Python, Numpy & Matplotlib Support")
 
     depends_on("cmake@3.12:", when="@:1.5.1")
-    depends_on("cmake@3.23:", when="@1.6.0:")
+    depends_on("cmake@3.19:", when="@1.6.0:")
     depends_on("catch2@2.13.4:2.13.9")
     depends_on("ports-of-call@1.2.0:", when="@:1.5.1")
     depends_on("ports-of-call@1.5.1:", when="@1.6.0:")


### PR DESCRIPTION
Use CMake 3.19 as minimum for latest `spiner` version

<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code is formatted. (You can use the format_spiner make target.)
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

