### PR TITLE
resolve get on device edge case

### DIFF
--- a/spiner/databox.hpp
+++ b/spiner/databox.hpp
@@ -302,7 +302,7 @@ class DataBox {
 
   DataBox<T, Grid_t, Concept>
   getOnDevice() const { // getOnDevice is always a deep copy
-    if (size == 0 || status_ == DataStatus::Empty) { // edge case for unallocated
+    if (size() == 0 || status_ == DataStatus::Empty) { // edge case for unallocated
       DataBox<T, Grid_t, Concept> a;
       return a;
     }

--- a/spiner/databox.hpp
+++ b/spiner/databox.hpp
@@ -42,7 +42,7 @@
 namespace Spiner {
 
 enum class IndexType { Interpolated = 0, Named = 1, Indexed = 2 };
-enum class DataStatus { Empty, Unmanaged, AllocatedHost, AllocatedDevice };
+enum class DataStatus { Empty = 0, Unmanaged = 1, AllocatedHost = 2, AllocatedDevice = 3 };
 enum class AllocationTarget { Host, Device };
 
 template <typename T = Real, typename Grid_t = RegularGrid1D<T>,
@@ -302,6 +302,10 @@ class DataBox {
 
   DataBox<T, Grid_t, Concept>
   getOnDevice() const { // getOnDevice is always a deep copy
+    if (size == 0 || status_ == DataStatus::Empty) { // edge case for unallocated
+      DataBox<T, Grid_t, Concept> a;
+      return a;
+    }
     // create device memory (host memory if no device)
     T *device_data = (T *)PORTABLE_MALLOC(sizeBytes());
     // copy to device

--- a/spiner/databox.hpp
+++ b/spiner/databox.hpp
@@ -42,7 +42,12 @@
 namespace Spiner {
 
 enum class IndexType { Interpolated = 0, Named = 1, Indexed = 2 };
-enum class DataStatus { Empty = 0, Unmanaged = 1, AllocatedHost = 2, AllocatedDevice = 3 };
+enum class DataStatus {
+  Empty = 0,
+  Unmanaged = 1,
+  AllocatedHost = 2,
+  AllocatedDevice = 3
+};
 enum class AllocationTarget { Host, Device };
 
 template <typename T = Real, typename Grid_t = RegularGrid1D<T>,
@@ -302,7 +307,8 @@ class DataBox {
 
   DataBox<T, Grid_t, Concept>
   getOnDevice() const { // getOnDevice is always a deep copy
-    if (size() == 0 || status_ == DataStatus::Empty) { // edge case for unallocated
+    if (size() == 0 ||
+        status_ == DataStatus::Empty) { // edge case for unallocated
       DataBox<T, Grid_t, Concept> a;
       return a;
     }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -676,6 +676,14 @@ SCENARIO("Copying a DataBox to device", "[DataBox][GetOnDevice]") {
     printf("free db_host\n");
     free(db_host);
   }
+  GIVEN("An empty databox");
+  DataBox db;
+  WHEN("We copy it to device") {
+    DataBox db2 = db.getOnDevice();
+    THEN("The new object is still empty") {
+      REQUIRE(db.dataStatus() == Spiner::DataStatus::Empty);
+    }
+  }
 }
 
 SCENARIO("Using unique pointers to garbage collect DataBox",


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

@chadmeyer noticed that `GetOnDevice` on an empty `DataBox` causes an assertion error related to array sizes. I think this was indicating an edge case in `GetOnDevice`: the edge case being being that `GetOnDevice` was attempting to copy memory to device even for unallocated `DataBox`es containing no memory.

This PR simply adds a little default code making `GetOnDevice` a no-op for empty `DataBox`es.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code is formatted. (You can use the format_spiner make target.)
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

