### PR TITLE
More CI fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,7 +112,7 @@ default:
       spack repo add ${DEVEL_SPACK_ROOT}/var/spack/repos/xcap_deployment
       spack repo add spack-repo
       spack repo list
-      spack config add upstreams:default:install_tree:${SPINER_SPACK_DIR}/opt/spack/
+      spack config add upstreams:default:install_tree:${PROJECT_SPACK_ROOT}/opt/spack/
       spack dev-build -q -j $(nproc) ${SPINER_SPACK_SPEC}
       spack env deactivate
       section end spack_build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ variables:
   SPINER_GCC_VERSION: "10.3.0"
   SPINER_CUDA_VERSION: "11.6.0"
   SPINER_OPENMPI_VERSION: "4.1.1"
-  SPINER_SPACK_SPEC: "spiner@main+python+test%gcc@=${SPINER_GCC_VERSION}"
+  SPINER_SPACK_SPEC: "spiner@main+python+test%gcc@=${SPINER_GCC_VERSION} ^openblas"
   COLOR_CYAN: "\e[1;36m"
   COLOR_PLAIN: "\e[0m"
   # uncomment to have the CI Spack installation for debugging
@@ -103,7 +103,7 @@ default:
       if [[ ${CI_JOB_NAME} =~ "a100" ]];
       then
         module load openmpi/${SPINER_OPENMPI_VERSION}-gcc_${SPINER_GCC_VERSION}
-        export SPINER_SPACK_SPEC="${SPINER_SPACK_SPEC}+hdf5+mpi+kokkos ^kokkos+wrapper+cuda cuda_arch=80 ^openmpi@${SPINER_OPENMPI_VERSION}";
+        export SPINER_SPACK_SPEC="${SPINER_SPACK_SPEC}+hdf5+mpi+kokkos ^kokkos+wrapper+cuda cuda_arch=80 ^openmpi@${SPINER_OPENMPI_VERSION} ^openblas";
       fi
     - |
       section start "spack_build[collapsed=true]" "Building via Spack"


### PR DESCRIPTION
## PR Summary

The currrent default configuration would pull in `intel-oneapi-mkl` as MKL provider, which causes troubles with `numpy`.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code is formatted. (You can use the format_spiner make target.)
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

