### PR TITLE
ci: add TESTING_CLUSTER to PROJECT_SPACK_ROOT

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,7 @@ default:
     - rm -rf ${SPACK_USER_CACHE_PATH} ${DEVEL_SPACK_ROOT}
     - |
       if [[ -z "${PROJECT_TMP_SPACK_DIR}" ]]; then
-        export PROJECT_SPACK_ROOT=${XCAP_PROJECT_DIR}/spack
+        export PROJECT_SPACK_ROOT="${XCAP_PROJECT_DIR}/spack-${TESTING_CLUSTER}"
       else
         export PROJECT_SPACK_ROOT="${XCAP_PROJECT_DIR}/${PROJECT_TMP_SPACK_DIR}-${TESTING_CLUSTER}"
       fi


### PR DESCRIPTION
## PR Summary

Spack upstreams are now split up by cluster.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code is formatted. (You can use the format_spiner make target.)
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

