### PR TITLE
Implement serialization and deserialization

### DIFF
--- a/doc/sphinx/src/databox.rst
+++ b/doc/sphinx/src/databox.rst
@@ -282,6 +282,18 @@ reconstruct itself. The return value is the amount of memory in bytes
 used in the array by the serialized ``DataBox`` object. This method is
 non-destructive; the original ``DataBox`` is unchanged. The function
 
+.. cpp:function:: std::size_t DataBox::setPointer(T *src);
+
+with the overload
+
+.. cpp:function:: std::size_t DataBox::setPointer(char *src);
+
+sets the underlying tabulated data from the src pointer, which is
+assumed to be the right size and shape. This is useful for the
+deSerialize function (described below) and for building your own
+serialization/de-serialization routines in composite objects. The
+function
+
 .. cpp:function:: std::size_t DataBox::deSerialize(char *src);
 
 initializes a ``DataBox`` to match the serialized ``DataBox``

--- a/doc/sphinx/src/databox.rst
+++ b/doc/sphinx/src/databox.rst
@@ -333,6 +333,16 @@ serialization/de-serialization probably looks like this:
   // read_size, write_size, and allocate_size should all be the same.
   assert((read_size == write_size) && (write_size == allocate_size));
 
+.. warning::
+
+  The serialization routines described here are **not** architecture
+  aware. Serializing and de-serializing on a single architecture
+  inside a single executable will work fine. However, do not use
+  serialization as a file I/O strategy, as there is no guarantee that
+  the serialized format for a ``DataBox`` on one architecture will be
+  the same as on another. This is due to, for example,
+  architecture-specific differences in endianness and padding.
+
 .. _`MPI Windows`: https://www.mpi-forum.org/docs/mpi-4.1/mpi41-report/node311.htm
 
 Accessing Elements of a ``DataBox``

--- a/spiner/databox.hpp
+++ b/spiner/databox.hpp
@@ -337,7 +337,7 @@ class DataBox {
     std::size_t offst = sizeof(*this);
     // now sizeBytes is well defined after copying the "header" of the source.
     if (sizeBytes() > 0) { // could also do data_ != nullptr
-      data_ = (double *)(src + offst);
+      data_ = (T *)(src + offst);
       status_ = DataStatus::Unmanaged;
       offst += sizeBytes();
     }

--- a/spiner/databox.hpp
+++ b/spiner/databox.hpp
@@ -352,6 +352,17 @@ class DataBox {
         (status_ == DataStatus::Empty || status_ == DataStatus::Unmanaged),
         "Must not de-serialize into an active databox.");
     memcpy(this, src, sizeof(*this));
+
+    // sanity check that de-serialization of trivially-copyable memory
+    // was reasonable
+    PORTABLE_REQUIRE(size() > 0, "All dimensions must be positive.");
+    PORTABLE_REQUIRE((size() > 0) || (rank_ == 0),
+                     "Size > 0 for all non-empty databoxes");
+    PORTABLE_REQUIRE((size() > 0) || status_ == DataStatus::Empty,
+                     "Size > 0 for all non-empty databoxes");
+    PORTABLE_REQUIRE(status_ != DataStatus::AllocatedDevice,
+                     "Serialization cannot be performed on device memory");
+
     std::size_t offst = sizeof(*this);
     // now sizeBytes is well defined after copying the "header" of the source.
     offst += setPointer(src + offst);

--- a/spiner/regular_grid_1d.hpp
+++ b/spiner/regular_grid_1d.hpp
@@ -62,21 +62,6 @@ class RegularGrid1D {
     PORTABLE_ALWAYS_REQUIRE(min_ < max_ && N_ > 0, "Valid grid");
   }
 
-  // Assignment operator
-  /*
-  Default copy constructable
-  PORTABLE_INLINE_FUNCTION RegularGrid1D &operator=(const RegularGrid1D &src) {
-    if (this != &src) {
-      min_ = src.min_;
-      max_ = src.max_;
-      dx_ = src.dx_;
-      idx_ = src.idx_;
-      N_ = src.N_;
-    }
-    return *this;
-  }
-  */
-
   // Forces x in the interval
   PORTABLE_INLINE_FUNCTION int bound(int ix) const {
 #ifndef SPINER_DISABLE_BOUNDS_CHECKS

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -620,7 +620,7 @@ SCENARIO("Serializing and deserializing a DataBox",
           std::size_t read_offst = dbh2.deSerialize(db_serial);
           REQUIRE(read_offst == write_offst);
 
-          AND_THEN("They do not point ot the same memory") {
+          AND_THEN("They do not point to the same memory") {
             // checks DataBox pointer
             REQUIRE(dbh2.data() != dbh.data());
             // checks accessor agrees

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -620,6 +620,13 @@ SCENARIO("Serializing and deserializing a DataBox",
           std::size_t read_offst = dbh2.deSerialize(db_serial);
           REQUIRE(read_offst == write_offst);
 
+          AND_THEN("They do not point ot the same memory") {
+            // checks DataBox pointer
+            REQUIRE(dbh2.data() != dbh.data());
+            // checks accessor agrees
+            REQUIRE(&dbh2(0) != &dbh(0));
+          }
+
           AND_THEN("The shape is correct") {
             REQUIRE(dbh2.rank() == dbh.rank());
             REQUIRE(dbh2.size() == dbh.size());

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -634,6 +634,9 @@ SCENARIO("Serializing and deserializing a DataBox",
             THEN("The second and third databoxes DO point at the same memory") {
               REQUIRE(dbh2.data() == dbh3.data());
               REQUIRE(&dbh3(0) == &dbh2(0));
+              AND_THEN("But they are separate objects") {
+                REQUIRE(&dbh2 != &dbh3);
+              }
             }
           }
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -53,8 +53,8 @@ PORTABLE_INLINE_FUNCTION Real linearFunction(Real b, Real a, Real z, Real y,
   return x + y + z + a + b;
 }
 
-TEST_CASE("PortableMDArrays can be allocated from a pointer",
-          "[PortableMDArray]") {
+SCENARIO("PortableMDArrays can be allocated from a pointer",
+         "[PortableMDArray]") {
   constexpr int N = 2;
   constexpr int M = 3;
   std::vector<int> data(N * M);
@@ -529,19 +529,22 @@ TEST_CASE("DataBox Interpolation with piecewise grids",
 
     WHEN("We construct and fill a 3D DataBox based on this grid") {
       constexpr int RANK = 3;
-      PiecewiseDB<NGRIDS> db(Spiner::AllocationTarget::Device, NCOARSE, NCOARSE,
-                             NCOARSE);
+      PiecewiseDB<NGRIDS> dbh(Spiner::AllocationTarget::Host, NCOARSE, NCOARSE,
+                              NCOARSE);
       for (int i = 0; i < RANK; ++i) {
-        db.setRange(i, g);
+        dbh.setRange(i, g);
       }
-      portableFor(
-          "Fill 3D Databox", 0, NCOARSE, 0, NCOARSE, 0, NCOARSE,
-          PORTABLE_LAMBDA(const int iz, const int iy, const int ix) {
+      for (int iz = 0; iz < NCOARSE; ++iz) {
+        for (int iy = 0; iy < NCOARSE; ++iy) {
+          for (int ix = 0; ix < NCOARSE; ++ix) {
             Real x = g.x(ix);
             Real y = g.x(iy);
             Real z = g.x(iz);
-            db(iz, iy, ix) = linearFunction(z, y, x);
-          });
+            dbh(iz, iy, ix) = linearFunction(z, y, x);
+          }
+        }
+      }
+      auto db = dbh.getOnDevice();
 
       THEN("We can interpolate it to a finer grid and get the right answer") {
         Real error = 0;
@@ -561,8 +564,83 @@ TEST_CASE("DataBox Interpolation with piecewise grids",
             error);
         REQUIRE(error <= EPSTEST);
       }
+
       // cleanup
       free(db);
+      free(dbh);
+    }
+  }
+}
+
+SCENARIO("Serializing and deserializing a DataBox",
+         "[DataBox][PiecewiseGrid1D][Serialize]") {
+  GIVEN("A piecewise grid") {
+    constexpr int NGRIDS = 2;
+    constexpr Real xmin = 0;
+    constexpr Real xmax = 1;
+
+    RegularGrid1D g1(xmin, 0.35 * (xmax - xmin), 3);
+    RegularGrid1D g2(0.35 * (xmax - xmin), xmax, 4);
+    PiecewiseGrid1D<NGRIDS> g = {{g1, g2}};
+
+    const int NCOARSE = g.nPoints();
+
+    THEN("The piecewise grid contains a number of points equal the sum of "
+         "the points of the individual grids") {
+      REQUIRE(g.nPoints() == g1.nPoints() + g2.nPoints());
+    }
+
+    WHEN("We construct and fill a 3D DataBox based on this grid") {
+      constexpr int RANK = 3;
+      PiecewiseDB<NGRIDS> dbh(Spiner::AllocationTarget::Host, NCOARSE, NCOARSE,
+                              NCOARSE);
+      for (int i = 0; i < RANK; ++i) {
+        dbh.setRange(i, g);
+      }
+      for (int iz = 0; iz < NCOARSE; ++iz) {
+        for (int iy = 0; iy < NCOARSE; ++iy) {
+          for (int ix = 0; ix < NCOARSE; ++ix) {
+            Real x = g.x(ix);
+            Real y = g.x(iy);
+            Real z = g.x(iz);
+            dbh(iz, iy, ix) = linearFunction(z, y, x);
+          }
+        }
+      }
+      WHEN("We serialize the DataBox") {
+        std::size_t serial_size = dbh.serializedSizeInBytes();
+        REQUIRE(serial_size == (sizeof(dbh) + dbh.sizeBytes()));
+
+        char *db_serial = (char *)malloc(serial_size * sizeof(char));
+        std::size_t write_offst = dbh.serialize(db_serial);
+        REQUIRE(write_offst == serial_size);
+
+        THEN("We can initialize a new databox based on the serialized one") {
+          PiecewiseDB<NGRIDS> dbh2;
+          std::size_t read_offst = dbh2.deSerialize(db_serial);
+          REQUIRE(read_offst == write_offst);
+
+          AND_THEN("The shape is correct") {
+            REQUIRE(dbh2.rank() == dbh.rank());
+            REQUIRE(dbh2.size() == dbh.size());
+            for (int d = 1; d <= 3; ++d) {
+              REQUIRE(dbh2.dim(d) == dbh.dim(d));
+            }
+          }
+
+          AND_THEN("The contents are correct") {
+            for (int i = 0; i < dbh.size(); ++i) {
+              REQUIRE(dbh(i) == dbh2(i));
+            }
+          }
+        }
+
+        // cleanup
+        free(db_serial);
+      }
+
+      // cleanup
+      free(dbh);
     }
   }
 }
@@ -702,7 +780,7 @@ SCENARIO("Using unique pointers to garbage collect DataBox",
 }
 
 #if SPINER_USE_HDF
-TEST_CASE("PiecewiseGrid HDF5", "[PiecewiseGrid1D][HDF5]") {
+SCENARIO("PiecewiseGrid HDF5", "[PiecewiseGrid1D][HDF5]") {
   GIVEN("A piecewise grid") {
     RegularGrid1D g1(0, 0.25, 3);
     RegularGrid1D g2(0.25, 0.75, 11);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -627,6 +627,16 @@ SCENARIO("Serializing and deserializing a DataBox",
             REQUIRE(&dbh2(0) != &dbh(0));
           }
 
+          WHEN("We initialize a THIRD databox on the serialized one") {
+            PiecewiseDB<NGRIDS> dbh3;
+            std::size_t read_offst3 = dbh3.deSerialize(db_serial);
+            REQUIRE(read_offst3 == write_offst);
+            THEN("The second and third databoxes DO point at the same memory") {
+              REQUIRE(dbh2.data() == dbh3.data());
+              REQUIRE(&dbh3(0) == &dbh2(0));
+            }
+          }
+
           AND_THEN("The shape is correct") {
             REQUIRE(dbh2.rank() == dbh.rank());
             REQUIRE(dbh2.size() == dbh.size());


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Using tabulated data in, e.g., MPI Windows for shared memory requires the ability to serialize a ``DataBox`` object into pre-allocated shared memory and to build a new thread-local object around said shared memory, so that the object itself is thread-local but it internally points at a table that lives in shared memory. This PR implements this capability.

This will be needed for the equivalent capability in `Singularity-EOS` and also provides a prototype for how that model and API will look.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code is formatted. (You can use the format_spiner make target.)
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

