### PR TITLE
Add 2-parameter, 1-index overload of interpToReal.

### DIFF
--- a/spiner/databox.hpp
+++ b/spiner/databox.hpp
@@ -193,6 +193,8 @@ class DataBox {
   PORTABLE_FORCEINLINE_FUNCTION T interpToReal(const T x) const noexcept;
   PORTABLE_FORCEINLINE_FUNCTION T interpToReal(const T x2,
                                                const T x1) const noexcept;
+  PORTABLE_FORCEINLINE_FUNCTION T interpToReal(const T x2, const T x1,
+                                               const int idx) const noexcept;
   PORTABLE_FORCEINLINE_FUNCTION T interpToReal(const T x3, const T x2,
                                                const T x1) const noexcept;
   PORTABLE_FORCEINLINE_FUNCTION T interpToReal(const T x3, const T x2,
@@ -470,6 +472,23 @@ PORTABLE_FORCEINLINE_FUNCTION T DataBox<T, Grid_t, Concept>::interpToReal(
               (w1[0] * dataView_(ix2, ix1) + w1[1] * dataView_(ix2, ix1 + 1)) +
           w2[1] * (w1[0] * dataView_(ix2 + 1, ix1) +
                    w1[1] * dataView_(ix2 + 1, ix1 + 1)));
+}
+
+template <typename T, typename Grid_t, typename Concept>
+PORTABLE_FORCEINLINE_FUNCTION T
+DataBox<T, Grid_t, Concept>::interpToReal(const T x2, const T x1, const int idx) const noexcept {
+  assert(canInterpToReal_(2));
+  int ix1, ix2;
+  weights_t<T> w1, w2;
+  grids_[1].weights(x1, ix1, w1);
+  grids_[2].weights(x2, ix2, w2);
+
+  // TODO: prefectch corners for speed?
+  // TODO: re-order access pattern?
+  return (w2[0] *
+              (w1[0] * dataView_(ix2, ix1, idx) + w1[1] * dataView_(ix2, ix1 + 1, idx)) +
+          w2[1] * (w1[0] * dataView_(ix2 + 1, ix1, idx) +
+                   w1[1] * dataView_(ix2 + 1, ix1 + 1, idx)));
 }
 
 template <typename T, typename Grid_t, typename Concept>

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -418,6 +418,24 @@ TEST_CASE("DataBox interpolation", "[DataBox]") {
     REQUIRE(error <= EPSTEST);
   }
 
+  SECTION("interpToReal in 3D with one non-interpolated index") {
+    Real error = 0;
+    for (int iz = 0; iz < NFINE; iz++) {
+      Real z = fine_grids[2].x(iz);
+      for (int iy = 0; iy < NFINE; iy++) {
+        Real y = fine_grids[1].x(iy);
+        for (int ix = 0; ix < NX; ix++) {
+          Real x = grids[0].x(ix);
+          Real f_true = linearFunction(z, y, x);
+          Real difference = db.interpToReal(z, y, ix) - f_true;
+          error += (difference * difference);
+        }
+      }
+    }
+    error = sqrt(error);
+    REQUIRE(error <= EPSTEST);
+  }
+
   SECTION("interpFromDB 3D->2D") {
     constexpr Real z = (zmax + zmin) / 2.;
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

* Add an overload of the `interpToReal` function to the `Databox` class that takes two interpolation parameters and one index, similar to the overload that takes three interpolation parameters and one index.
* This is intended to support 2D interpolation with a non-interpolatable 3rd index.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code is formatted. (You can use the format_spiner make target.)
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

