### PR TITLE
spack: remove ^kokkos~shared requirement

### DIFF
--- a/spack-repo/packages/spiner/package.py
+++ b/spack-repo/packages/spiner/package.py
@@ -63,10 +63,7 @@ class Spiner(CMakePackage):
     depends_on("ports-of-call portability_strategy=Kokkos", when="@:1.5.1 +kokkos")
     depends_on("ports-of-call portability_strategy=None", when="@:1.5.1 ~kokkos")
     depends_on("kokkos@3.3.00:", when="+kokkos")
-    requires(
-        "^kokkos ~shared+cuda_lambda+cuda_constexpr",
-        when="+kokkos ^kokkos+cuda",
-    )
+    requires("^kokkos+cuda_lambda+cuda_constexpr", when="+kokkos ^kokkos+cuda")
 
     depends_on("hdf5+hl~mpi", when="+hdf5~mpi")
     depends_on("hdf5+hl+mpi", when="+hdf5+mpi")


### PR DESCRIPTION
## PR Summary

Removes `kokkos~shared` requirement which prevented other codes from using Spiner.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code is formatted. (You can use the format_spiner make target.)
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

