### PR TITLE
Fix Debug assertion in recently added interpToReal overload (sorry).

### DIFF
--- a/spiner/databox.hpp
+++ b/spiner/databox.hpp
@@ -477,7 +477,12 @@ PORTABLE_FORCEINLINE_FUNCTION T DataBox<T, Grid_t, Concept>::interpToReal(
 template <typename T, typename Grid_t, typename Concept>
 PORTABLE_FORCEINLINE_FUNCTION T
 DataBox<T, Grid_t, Concept>::interpToReal(const T x2, const T x1, const int idx) const noexcept {
-  assert(canInterpToReal_(2));
+  assert(rank_ == 3);
+  for (int r = 1; r < rank_; ++r) {
+    assert(indices_[r] == IndexType::Interpolated);
+    assert(grids_[r].isWellFormed());
+  }
+
   int ix1, ix2;
   weights_t<T> w1, w2;
   grids_[1].weights(x1, ix1, w1);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

* A recently added interpToReal (by @RyanWollaeger) for databox implemented an incorrect assertion, which is only active in Debug builds.
* The updated assertions for the rank-3, 2-axis interpolation overload has been modified to be similar to the older rank-4, 3-axis interpolation assertions.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code is formatted. (You can use the format_spiner make target.)
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

