### PR TITLE
Update spinerConfig.cmake.in to ensure targets exist downstream

### DIFF
--- a/cmake/spinerConfig.cmake.in
+++ b/cmake/spinerConfig.cmake.in
@@ -6,6 +6,13 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(ports-of-call)
 
+if(@SPINER_ENABLE_HDF5@)
+  find_dependency(hdf5 COMPONENTS C HL)
+  if(@HDF5_IS_PARALLEL@)
+    find_dependency(MPI COMPONENTS CXX)
+  endif()
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/spinerTargets.cmake")
 
 check_required_components(spiner)


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

`cmake/spinerCMake.config` wouldn't check for `hdf5`,`mpi` targets, which could cause downstream codes to fail the CMake configure stage.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code is formatted. (You can use the format_spiner make target.)
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

