### PR TITLE
cmake: fix HDF5 dependency logic for installed spinerConfig.cmake

### DIFF
--- a/cmake/spinerConfig.cmake.in
+++ b/cmake/spinerConfig.cmake.in
@@ -6,9 +6,9 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(ports-of-call)
 
-if(@SPINER_ENABLE_HDF5@)
+if(@SPINER_USE_HDF@)
   find_dependency(hdf5 COMPONENTS C HL)
-  if(@HDF5_IS_PARALLEL@)
+  if(HDF5_IS_PARALLEL)
     find_dependency(MPI COMPONENTS CXX)
   endif()
 endif()


### PR DESCRIPTION
## PR Summary

The `spinerConfig.cmake` was using a non-existing variable and therefore always false.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code is formatted. (You can use the format_spiner make target.)
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

