### PR TITLE
cmake: use HDF5 instead of hdf5 in spinerConfig.cmake for consistency

### DIFF
--- a/cmake/spinerConfig.cmake.in
+++ b/cmake/spinerConfig.cmake.in
@@ -7,7 +7,7 @@ include(CMakeFindDependencyMacro)
 find_dependency(ports-of-call)
 
 if(@SPINER_USE_HDF@)
-  find_dependency(hdf5 COMPONENTS C HL)
+  find_dependency(HDF5 COMPONENTS C HL)
   if(HDF5_IS_PARALLEL)
     find_dependency(MPI COMPONENTS CXX)
   endif()


### PR DESCRIPTION
## PR Summary

Don't mix `find_package(hdf5)` and `find_package(HDF5)`. Use `find_dependency(HDF5)` for consistency.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code is formatted. (You can use the format_spiner make target.)
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

