### PR TITLE
Prepare for Spack v1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 cmake_minimum_required(VERSION 3.19)
 
 set(SPINER_VERSION 1.6.4)
-project(spiner VERSION ${SPINER_VERSION})
+project(spiner VERSION ${SPINER_VERSION} LANGUAGES CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/spack-repo/packages/ports-of-call/package.py
+++ b/spack-repo/packages/ports-of-call/package.py
@@ -52,6 +52,8 @@ class PortsOfCall(CMakePackage):
         when="@1.6.1: +test",
     )
 
+    depends_on("cxx", type="build")
+
     depends_on("cmake@3.12:")
     depends_on("catch2@3.0.1:", when="+test")
     depends_on("kokkos", when="+test test_portability_strategy=Kokkos")

--- a/spack-repo/packages/spiner/package.py
+++ b/spack-repo/packages/spiner/package.py
@@ -53,6 +53,8 @@ class Spiner(CMakePackage):
 
     variant("test", default=False, description="Build tests")
 
+    depends_on("cxx", type="build")
+
     depends_on("cmake@3.12:", when="@:1.5.1")
     depends_on("cmake@3.19:", when="@1.6.0:")
     depends_on("catch2@3.7.1:", when="@1.6.3: +test")
@@ -95,7 +97,6 @@ class Spiner(CMakePackage):
             )
         if self.spec.satisfies("^kokkos+rocm"):
             args.append(self.define("CMAKE_CXX_COMPILER", self.spec["hip"].hipcc))
-            args.append(self.define("CMAKE_C_COMPILER", self.spec["hip"].hipcc))
         if self.spec.satisfies("^kokkos+cuda"):
             args.append(self.define("CMAKE_CXX_COMPILER", self.spec["kokkos"].kokkos_cxx))
         return args


### PR DESCRIPTION
## PR Summary

These changes are backwards compatible all the way to v0.23. Since Singularity-EOS already has them, we should just bring this library up-to-date. There is more Spack related changes incoming due to the Package API v2 changes, but that will be its own PR.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code is formatted. (You can use the format_spiner make target.)
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

