### PR TITLE
spack: c dependency gets pulled in through other libs

### DIFF
--- a/spack-repo/packages/spiner/package.py
+++ b/spack-repo/packages/spiner/package.py
@@ -53,6 +53,7 @@ class Spiner(CMakePackage):
 
     variant("test", default=False, description="Build tests")
 
+    depends_on("c", type="build")
     depends_on("cxx", type="build")
 
     depends_on("cmake@3.12:", when="@:1.5.1")


### PR DESCRIPTION
## PR Summary

HDF5 and potentially other dependencies pull in a C compiler dependency. So turn this on by default.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code is formatted. (You can use the format_spiner make target.)
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] If preparing for a new release, update the version in cmake.

