### PR TITLE
remove dx and comparators from databox and grid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ convergence.bin
 *.hpp.gch
 convergence.dat
 .markdown-preview.html
+*.h5
 *.sp5
 *.lst
 *.s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [[MR 141]](https://github.com/lanl/spiner/pull/142) fix issue with range() method on device
 
 ### Changed (changing behavior/API/variables/...)
+- [[MR 145]](https://github.com/lanl/spiner/pull/145) Remove comparator and dx methods from public API
 
 ### Infrastructure (changes irrelevant to downstream codes)
 - [[MR 141]](https://github.com/lanl/spiner/pull/142) update contribution rules

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -66,4 +66,6 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
-This documentation is approved for unlimited release, LA-UR-22-20363.
+This documentation is approved for unlimited release,
+LA-UR-22-20363. Generative AI was used to assist in modifying this
+file.

--- a/doc/sphinx/src/interpolation.rst
+++ b/doc/sphinx/src/interpolation.rst
@@ -77,12 +77,6 @@ returns the maximum value on the independent variable grid.
 
 The function
 
-.. cpp:function:: T RegularGrid1D::dx() const;
-
-returns the grid spacing for the independent variable.
-
-The function
-
 .. cpp:function:: int RegularGrid1D::nPoints() const;
 
 returns the number of points in the independent variable grid.

--- a/spiner/databox.hpp
+++ b/spiner/databox.hpp
@@ -282,10 +282,6 @@ class DataBox {
   PORTABLE_INLINE_FUNCTION bool ownsAllocatedMemory() {
     return (status_ != DataStatus::Unmanaged);
   }
-  inline bool operator==(const DataBox<T, Grid_t, Concept> &other) const;
-  inline bool operator!=(const DataBox<T, Grid_t, Concept> &other) const {
-    return !(*this == other);
-  }
 
   // call this to tell a databox it no longer owns its memory
   PORTABLE_INLINE_FUNCTION void makeShallow() {
@@ -995,20 +991,6 @@ DataBox<T, Grid_t, Concept>::copy(const DataBox<T, Grid_t, Concept> &src) {
   copyMetadata(src);
   for (int i = 0; i < src.size(); i++)
     dataView_(i) = src(i);
-}
-
-template <typename T, typename Grid_t, typename Concept>
-inline bool DataBox<T, Grid_t, Concept>::operator==(
-    const DataBox<T, Grid_t, Concept> &other) const {
-  if (rank_ != other.rank_) return false;
-  for (int i = 0; i < rank_; i++) {
-    if (indices_[i] != other.indices_[i]) return false;
-    if (indices_[i] == IndexType::Interpolated &&
-        grids_[i] != other.grids_[i]) {
-      return false;
-    }
-  }
-  return dataView_ == other.dataView_;
 }
 
 // TODO: should this be std::reduce?

--- a/spiner/piecewise_grid_1d.hpp
+++ b/spiner/piecewise_grid_1d.hpp
@@ -146,25 +146,10 @@ class PiecewiseGrid1D {
     ix += pointTotals_[ig];
   }
 
-  PORTABLE_INLINE_FUNCTION
-  bool operator==(const PiecewiseGrid1D<T, NGRIDSMAX> &other) const {
-    for (int ig = 0; ig < NGRIDS_; ++ig) {
-      if (grids_[ig] != other.grids_[ig]) return false;
-    }
-    return true;
-  }
-  PORTABLE_INLINE_FUNCTION
-  bool operator!=(const PiecewiseGrid1D<T, NGRIDSMAX> &other) const {
-    return !(*this == other);
-  }
   PORTABLE_INLINE_FUNCTION T min() const { return grids_[0].min(); }
   PORTABLE_INLINE_FUNCTION T max() const { return grids_[NGRIDS_ - 1].max(); }
   PORTABLE_INLINE_FUNCTION size_t nPoints() const {
     return pointTotals_[NGRIDS_ - 1] + grids_[NGRIDS_ - 1].nPoints();
-  }
-  PORTABLE_INLINE_FUNCTION T dx(const int ig) const {
-    assert(ig < NGRIDS_);
-    return grids_[ig].dx();
   }
   PORTABLE_INLINE_FUNCTION bool isnan() const {
     for (int ig = 0; ig < NGRIDS_; ++ig) {

--- a/spiner/regular_grid_1d.hpp
+++ b/spiner/regular_grid_1d.hpp
@@ -100,18 +100,8 @@ class RegularGrid1D {
   }
 
   // utitilies
-  PORTABLE_INLINE_FUNCTION bool
-  operator==(const RegularGrid1D<T> &other) const {
-    return (min_ == other.min_ && max_ == other.max_ && dx_ == other.dx_ &&
-            idx_ == other.idx_ && N_ == other.N_);
-  }
-  PORTABLE_INLINE_FUNCTION bool
-  operator!=(const RegularGrid1D<T> &other) const {
-    return !(*this == other);
-  }
   PORTABLE_INLINE_FUNCTION T min() const { return min_; }
   PORTABLE_INLINE_FUNCTION T max() const { return max_; }
-  PORTABLE_INLINE_FUNCTION T dx() const { return dx_; }
   PORTABLE_INLINE_FUNCTION size_t nPoints() const { return N_; }
   PORTABLE_INLINE_FUNCTION bool isnan() const {
     return (std::isnan(min_) || std::isnan(max_) || std::isnan(dx_) ||

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -1,4 +1,4 @@
-// © (or copyright) 2019-2021. Triad National Security, LLC. All rights
+// © (or copyright) 2019-2026. Triad National Security, LLC. All rights
 // reserved.  This program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which is
 // operated by Triad National Security, LLC for the U.S.  Department of
@@ -10,6 +10,8 @@
 // in this material to reproduce, prepare derivative works, distribute
 // copies to the public, perform publicly and display publicly, and to
 // permit others to do so.
+
+// Generative AI was used to modify this file
 
 #include <cmath>
 #include <cstdio>

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -98,7 +98,8 @@ int main(int argc, char *argv[]) {
     for (int ifine = 0; ifine < nfine.size(); ++ifine) {
       auto n = nfine[ifine];
       auto g = gfine[ifine];
-      Real d3x = g.dx() * g.dx() * g.dx();
+      const Real dx = g.x(1) - g.x(0);
+      Real d3x = dx * dx * dx;
       Real L2_error;
 #ifdef PORTABILITY_STRATEGY_KOKKOS
       Kokkos::fence();

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -103,7 +103,6 @@ TEST_CASE("RegularGrid1D", "[RegularGrid1D]") {
     REQUIRE(g.min() == min);
     REQUIRE(g.max() == max);
     REQUIRE(g.nPoints() == N);
-    REQUIRE(g.dx() == (max - min) / ((Real)(N - 1)));
   }
 
   SECTION("A regular grid can be serialized and deserialized") {
@@ -116,9 +115,14 @@ TEST_CASE("RegularGrid1D", "[RegularGrid1D]") {
     RegularGrid1D restored;
     const std::size_t consumed = restored.deSerialize(serialized.data());
     REQUIRE(consumed == written);
-    REQUIRE(restored == grid);
+    REQUIRE(restored.min() == grid.min());
+    REQUIRE(restored.max() == grid.max());
+    REQUIRE(restored.nPoints() == grid.nPoints());
     REQUIRE(restored.setPointer(serialized.data()) == 0);
-    REQUIRE(restored.getOnDevice() == grid);
+    const auto device_grid = restored.getOnDevice();
+    REQUIRE(device_grid.min() == grid.min());
+    REQUIRE(device_grid.max() == grid.max());
+    REQUIRE(device_grid.nPoints() == grid.nPoints());
     restored.finalize();
     grid.finalize();
   }
@@ -189,12 +193,16 @@ TEST_CASE("PiecewiseGrid1D", "[PiecewiseGrid1D]") {
 
         PiecewiseGrid1D<3> restored;
         REQUIRE(restored.deSerialize(serialized.data()) == expected);
-        REQUIRE(restored == h);
+        REQUIRE(restored.nPoints() == h.nPoints());
+        for (std::size_t i = 0; i < h.nPoints(); ++i)
+          REQUIRE(restored.x(i) == h.x(i));
         REQUIRE(restored.nPoints() == h.nPoints());
         REQUIRE(restored.index(0.8) == h.index(0.8));
 
         auto device = h.getOnDevice();
-        REQUIRE(device == h);
+        REQUIRE(device.nPoints() == h.nPoints());
+        for (std::size_t i = 0; i < h.nPoints(); ++i)
+          REQUIRE(device.x(i) == h.x(i));
         device.finalize();
         restored.finalize();
       }
@@ -248,8 +256,6 @@ TEST_CASE("DataBox Basics", "[DataBox]") {
         REQUIRE(dbCopy.dim(i + 1) == db.dim(i + 1));
         REQUIRE(dbCopy.indexType(i) == db.indexType(i));
       }
-      REQUIRE(dbCopy != db);
-
       SECTION("DataBoxes can be resized") {
         dbCopy.resize(5, 4, 3);
         REQUIRE(dbCopy.rank() == 3);
@@ -290,7 +296,6 @@ TEST_CASE("DataBox Basics", "[DataBox]") {
       }
 
       SECTION("DataBox slices are shallow") {
-        REQUIRE(dbslc == dbslc2);
         REQUIRE(&(dbslc(0)) == &(db(0)));
       }
     }
@@ -772,7 +777,9 @@ SCENARIO("Serializing and deserializing a DataBox",
           AND_THEN("The grid metadata is correct") {
             for (int i = 0; i < RANK; ++i) {
               REQUIRE(dbh2.indexType(i) == IndexType::Interpolated);
-              REQUIRE(dbh2.range(i) == dbh.range(i));
+              REQUIRE(dbh2.range(i).nPoints() == dbh.range(i).nPoints());
+              for (std::size_t j = 0; j < dbh.range(i).nPoints(); ++j)
+                REQUIRE(dbh2.range(i).x(j) == dbh.range(i).x(j));
             }
           }
         }
@@ -788,7 +795,7 @@ SCENARIO("Serializing and deserializing a DataBox",
 }
 
 /* A mocked up UniformGrid1D that owns an array of data.
- * TODO(JMM): Remove/replace/update this once we have a NonuniformGrid1D.
+ * TODO(JMM): Remove/replace/update this once we have a NonUniformGrid1D.
  */
 class OwningTestGrid1D {
  public:
@@ -823,20 +830,6 @@ class OwningTestGrid1D {
   }
   PORTABLE_INLINE_FUNCTION bool isWellFormed() const {
     return points_ != nullptr && n_ > 1;
-  }
-  PORTABLE_INLINE_FUNCTION bool
-  operator==(const OwningTestGrid1D &other) const {
-    if (n_ != other.n_) {
-      return false;
-    }
-    for (std::size_t i = 0; i < n_; ++i) {
-      if (points_[i] != other.points_[i]) return false;
-    }
-    return true;
-  }
-  PORTABLE_INLINE_FUNCTION bool
-  operator!=(const OwningTestGrid1D &other) const {
-    return !(*this == other);
   }
   std::size_t dynamicMemorySizeInBytes() const { return n_ * sizeof(Real); }
   std::size_t serializedSizeInBytes() const {
@@ -964,7 +957,9 @@ TEST_CASE("DataBox delegates resource management to every grid",
           reinterpret_cast<const std::byte *>(restored.range(i).data());
       REQUIRE(gridData >= begin);
       REQUIRE(gridData < end);
-      REQUIRE(restored.range(i) == db.range(i));
+      REQUIRE(restored.range(i).nPoints() == db.range(i).nPoints());
+      for (std::size_t j = 0; j < db.range(i).nPoints(); ++j)
+        REQUIRE(restored.range(i).data()[j] == db.range(i).data()[j]);
       restored.range(i).finalize();
     }
     REQUIRE(OwningTestGrid1D::owned_allocations == RANK);
@@ -1117,7 +1112,7 @@ SCENARIO("PiecewiseGrid HDF5", "[PiecewiseGrid1D][HDF5]") {
     RegularGrid1D g3(0.75, 1, 7);
     PiecewiseGrid1D<3> piecewise_grid = {{g1, g2, g3}};
     THEN("We can save it to file") {
-      const std::string filename = "piecewise_test.h5";
+      const std::string filename = "piecewise_test.sp5";
       const std::string grid_name = "grid";
       herr_t status;
       hid_t file;
@@ -1135,13 +1130,15 @@ SCENARIO("PiecewiseGrid HDF5", "[PiecewiseGrid1D][HDF5]") {
         status += H5Fclose(file);
         REQUIRE(status == H5_SUCCESS);
 
-        REQUIRE(loaded_grid == piecewise_grid);
+        REQUIRE(loaded_grid.nPoints() == piecewise_grid.nPoints());
+        for (std::size_t i = 0; i < piecewise_grid.nPoints(); ++i)
+          REQUIRE(loaded_grid.x(i) == piecewise_grid.x(i));
       }
     }
     GIVEN("A single regular grid") {
       RegularGrid1D g1(0, 0.25, 3);
       WHEN("We save it to file") {
-        const std::string filename = "backwards_compatibility_test.h5";
+        const std::string filename = "backwards_compatibility_test.sp5";
         const std::string grid_name = "grid";
         herr_t status;
         hid_t file;
@@ -1199,7 +1196,9 @@ SCENARIO("DataBox HDF5", "[DataBox][HDF5]") {
           REQUIRE(db.indexType(i) == db2.indexType(i));
           REQUIRE(db.dim(i + 1) == db2.dim(i + 1));
           if (db.indexType(i) == IndexType::Interpolated) {
-            REQUIRE(db.range(i) == db2.range(i));
+            REQUIRE(db.range(i).nPoints() == db2.range(i).nPoints());
+            for (std::size_t j = 0; j < db.range(i).nPoints(); ++j)
+              REQUIRE(db.range(i).x(j) == db2.range(i).x(j));
           }
         }
         AND_THEN("Data itself is consistent") {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Improve interpToDB routines.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

While working on the NonUniformGrid1D MR, I realized that I was adding quite a lot of code to support methods that actually aren't used downstream and are sometimes not really doing what the name would imply anyway.

I figured then now is a good time to remove them. So here I remove dx and == and != from the public API for DataBox and Grid types.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code is formatted. (You can use the format_spiner make target.)
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Document any new features, update documentation for changes made.
- [x] Update the CHANGELOG.md file.
- [x] Make sure the copyright notice on any files you modified is up to date.
- [ ] LANL employees: make sure tests pass both on the github CI and on the Darwin CI
- [x] If ML was used, make sure to add a disclaimer at the top of a file indicating ML was used to assist in generating the file.
- [ ] If Agentic AI was used, have the AI generate a "proposed changes" markdown file and store it in the `plan_histories` folder, with a filename the same as the MR number.

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
- [ ] Maintainers: ensure spackages are up to date:
  - [ ] LANL-internal team, update XCAP spackages
  - [ ] Current maintainer of upstream spackages, submit MR to spack
